### PR TITLE
Add arguments support to umbraco-quickstart skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ These skills are your entry points for Umbraco backoffice extension development.
 **Start here if you're new.** Sets up everything in one command:
 
 ```bash
-# Full setup - creates Umbraco instance and extension
+# Full setup with custom credentials
+/umbraco-quickstart MyUmbracoSite MyExtension me@example.com MyPassword1234
+
+# With default credentials (admin@test.com / SecurePass1234)
 /umbraco-quickstart MyUmbracoSite MyExtension
 
 # Just instance name - will prompt for extension name
@@ -46,6 +49,7 @@ This skill will:
 2. Create an extension
 3. Register the extension with the Umbraco project
 4. Warn about missing CMS/UUI source
+5. Enter plan mode to help design your extension
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,19 +26,26 @@ Install the plugins:
 
 These skills are your entry points for Umbraco backoffice extension development. Start here.
 
-### `umbraco-quickstart` - Smart Environment Check
+### `umbraco-quickstart` - Quick Setup
 
-**Start here if you're new.** This skill checks your environment and sets up what's needed automatically.
-
-It detects:
-- Whether you have an Umbraco instance
-- Any existing extensions
-- If testing skills are installed
-- If Umbraco CMS source is available (for better code generation)
+**Start here if you're new.** Sets up everything in one command:
 
 ```bash
+# Full setup - creates Umbraco instance and extension
+/umbraco-quickstart MyUmbracoSite MyExtension
+
+# Just instance name - will prompt for extension name
+/umbraco-quickstart MyUmbracoSite
+
+# No arguments - detects existing or prompts for names
 /umbraco-quickstart
 ```
+
+This skill will:
+1. Create an Umbraco instance (if needed)
+2. Create an extension
+3. Register the extension with the Umbraco project
+4. Warn about missing CMS/UUI source
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ These skills are your entry points for Umbraco backoffice extension development.
 
 ```bash
 # Full setup with custom credentials
-/umbraco-quickstart MyUmbracoSite MyExtension me@example.com MyPassword1234
+/umbraco-quickstart MyUmbracoSite MyExtension --email a@a.co.uk --password Admin123456
 
 # With default credentials (admin@test.com / SecurePass1234)
 /umbraco-quickstart MyUmbracoSite MyExtension

--- a/plugins/umbraco-backoffice-skills/skills/package-script-writer/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/package-script-writer/SKILL.md
@@ -32,7 +32,7 @@ Generate and run Umbraco CMS installation scripts using the `psw` CLI tool.
 
 ```bash
 export PATH="$PATH:$HOME/.dotnet/tools"
-psw -d -n ProjectName -s ProjectName -u --database-type SQLite --admin-email admin@test.com --admin-password "SecurePass123!" --auto-run
+psw -d -n ProjectName -s ProjectName -u --database-type SQLite --admin-email admin@test.com --admin-password SecurePass1234 --auto-run
 ```
 
 Run this with `run_in_background: true` since Umbraco is a long-running web server.
@@ -43,7 +43,7 @@ Run this with `run_in_background: true` since Umbraco is a long-running web serv
 - `--auto-run` - execute the script immediately
 - Never combine `-o` with `--auto-run` (truncates the script)
 
-**Default credentials:** `admin@test.com` / `SecurePass123!`
+**Default credentials:** `admin@test.com` / `SecurePass1234`
 
 ## With Packages
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -1,16 +1,37 @@
 ---
 name: umbraco-quickstart
-description: Getting started router - detects your environment and sets up what's needed
+description: Quick setup for Umbraco extension development - creates instance, extension, and registers it
+argument-hint: "[UmbracoProjectName] [ExtensionName]"
 user_invocable: true
 ---
 
 # Umbraco Quickstart
 
-Detects your environment and sets up what's needed to create a working extension.
+Sets up everything needed for Umbraco extension development in one command.
+
+## Usage
+
+```bash
+# Full setup with names provided
+/umbraco-quickstart MyUmbracoSite MyExtension
+
+# Just Umbraco instance name (will prompt for extension name)
+/umbraco-quickstart MyUmbracoSite
+
+# No arguments (will detect existing or prompt for names)
+/umbraco-quickstart
+```
 
 ## Workflow
 
-### 1. Check what exists
+### 1. Parse arguments
+
+- **First argument**: Umbraco project name (e.g., "MyUmbracoSite")
+- **Second argument**: Extension name (e.g., "MyExtension")
+
+If arguments not provided, check what exists and prompt for missing names.
+
+### 2. Check what exists
 
 **Check for Umbraco instance:**
 ```bash
@@ -22,41 +43,24 @@ find . -name "*.csproj" -exec grep -l "Umbraco.Cms" {} \; 2>/dev/null | head -5
 find . -name "umbraco-package.json" 2>/dev/null | head -10
 ```
 
-**Check for Umbraco CMS source in extended workspace:**
-- Look for `Umbraco.Web.UI.Client/src` in current and extended workspace directories
-- Extended workspace includes directories added via `/add-dir`
+### 3. Take action
 
-**Check for UUI library source in extended workspace:**
-- Look for `@umbraco-ui/uui` packages in extended workspace directories
+**If no Umbraco instance:**
+- Use the provided name (first argument) or prompt for one
+- Create with `/package-script-writer [ProjectName]`
 
-**Check if testing skills are installed:**
-- Check if `umbraco-testing` skill is available
+**If no extension:**
+- Use the provided name (second argument) or prompt for one
+- Create with `/umbraco-extension-template [ExtensionName]`
 
-### 2. Take action based on findings
+**If extension not registered:**
+- Register with `/umbraco-add-extension-reference [ExtensionName]`
 
-**If no Umbraco instance → Create one:**
-```
-No Umbraco project found. Creating one with /package-script-writer...
-```
-Then use `/package-script-writer` to create it.
+### 4. Warn about optional resources
 
-**If no extensions → Create one:**
-```
-No extensions found. Creating one with /umbraco-extension-template...
-```
-Then use `/umbraco-extension-template` to create it.
+Check extended workspace (including `/add-dir` directories) and warn if missing:
 
-**If extension not registered → Register it:**
-```
-Extension found but not registered. Registering with /umbraco-add-extension-reference...
-```
-Then use `/umbraco-add-extension-reference` to register it.
-
-### 3. Warn about missing resources
-
-Only warn (don't block) if these are missing:
-
-**If CMS source not in extended workspace:**
+**If CMS source not found:**
 ```
 ⚠ Umbraco CMS source not found in extended workspace.
   For better code generation, add it:
@@ -64,7 +68,7 @@ Only warn (don't block) if these are missing:
   /add-dir /path/to/Umbraco-CMS/src/Umbraco.Web.UI.Client
 ```
 
-**If UUI source not in extended workspace:**
+**If UUI source not found:**
 ```
 ⚠ UUI library source not found in extended workspace.
   For UI component reference, add it:
@@ -81,14 +85,16 @@ Only warn (don't block) if these are missing:
 
 ## Goal
 
-The aim is to get the user to a working extension as quickly as possible. Don't just report - take action.
+Get the user to a working extension as quickly as possible. Don't just report - take action.
 
-## Available skills
+## Example
 
-| Skill | Purpose |
-|-------|---------|
-| `/package-script-writer` | Create Umbraco instance |
-| `/umbraco-backoffice` | Understand extension map |
-| `/umbraco-extension-template` | Create new extension |
-| `/umbraco-add-extension-reference` | Register extension |
-| `/umbraco-testing` | Testing guidance (if installed) |
+```bash
+/umbraco-quickstart MyUmbracoSite MyDashboard
+```
+
+This will:
+1. Create Umbraco instance "MyUmbracoSite" (if not exists)
+2. Create extension "MyDashboard"
+3. Register the extension with the Umbraco project
+4. Warn about missing CMS/UUI source if applicable

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -2,6 +2,7 @@
 name: umbraco-quickstart
 description: Quick setup for Umbraco extension development - creates instance, extension, and registers it
 argument-hint: "[UmbracoProjectName] [ExtensionName]"
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 user_invocable: true
 ---
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -83,6 +83,30 @@ Check extended workspace (including `/add-dir` directories) and warn if missing:
   /plugin install umbraco-cms-backoffice-testing-skills@umbraco-backoffice-marketplace
 ```
 
+### 5. Plan what to build
+
+Once setup is complete, ask the user what they want to build:
+
+```
+✅ Setup complete! Your extension is ready.
+
+What would you like to build? For example:
+- A custom dashboard
+- A property editor
+- A tree view in Settings
+- A content action
+- Something else?
+
+I can help you plan the implementation. Just describe what you want to create.
+```
+
+If the user describes what they want:
+1. Use `/umbraco-backoffice` to identify which extension types are needed
+2. Create a plan with the specific skills required
+3. Ask if they want to proceed with the implementation
+
+This turns quickstart into a complete onboarding experience - from zero to building.
+
 ## Goal
 
 Get the user to a working extension as quickly as possible. Don't just report - take action.

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -87,6 +87,15 @@ Check extended workspace (including `/add-dir` directories) and warn if missing:
 
 Get the user to a working extension as quickly as possible. Don't just report - take action.
 
+## Default Credentials
+
+When creating an Umbraco instance, these defaults are used:
+
+- **Email:** `admin@test.com`
+- **Password:** `SecurePass1234`
+
+These are safe for local development and don't contain special characters that cause escaping issues.
+
 ## Example
 
 ```bash
@@ -98,3 +107,5 @@ This will:
 2. Create extension "MyDashboard"
 3. Register the extension with the Umbraco project
 4. Warn about missing CMS/UUI source if applicable
+
+**Login with:** `admin@test.com` / `SecurePass1234`

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: umbraco-quickstart
 description: Quick setup for Umbraco extension development - creates instance, extension, and registers it
-argument-hint: "[UmbracoProjectName] [ExtensionName]"
+argument-hint: "[UmbracoProjectName] [ExtensionName] [AdminEmail] [AdminPassword]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 user_invocable: true
 ---
@@ -13,7 +13,10 @@ Sets up everything needed for Umbraco extension development in one command.
 ## Usage
 
 ```bash
-# Full setup with names provided
+# Full setup with all options
+/umbraco-quickstart MyUmbracoSite MyExtension me@example.com MyPassword1234
+
+# With default credentials (admin@test.com / SecurePass1234)
 /umbraco-quickstart MyUmbracoSite MyExtension
 
 # Just Umbraco instance name (will prompt for extension name)
@@ -29,6 +32,8 @@ Sets up everything needed for Umbraco extension development in one command.
 
 - **First argument**: Umbraco project name (e.g., "MyUmbracoSite")
 - **Second argument**: Extension name (e.g., "MyExtension")
+- **Third argument** (optional): Admin email (default: `admin@test.com`)
+- **Fourth argument** (optional): Admin password (default: `SecurePass1234`)
 
 If arguments not provided, check what exists and prompt for missing names.
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: umbraco-quickstart
 description: Quick setup for Umbraco extension development - creates instance, extension, and registers it
-argument-hint: "[UmbracoProjectName] [ExtensionName] [AdminEmail] [AdminPassword]"
+argument-hint: "[UmbracoProjectName] [ExtensionName] [--email admin@example.com] [--password Admin123456]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 user_invocable: true
 ---
@@ -13,8 +13,8 @@ Sets up everything needed for Umbraco extension development in one command.
 ## Usage
 
 ```bash
-# Full setup with all options
-/umbraco-quickstart MyUmbracoSite MyExtension me@example.com MyPassword1234
+# Full setup with custom credentials
+/umbraco-quickstart MyUmbracoSite MyExtension --email a@a.co.uk --password Admin123456
 
 # With default credentials (admin@test.com / SecurePass1234)
 /umbraco-quickstart MyUmbracoSite MyExtension
@@ -32,8 +32,8 @@ Sets up everything needed for Umbraco extension development in one command.
 
 - **First argument**: Umbraco project name (e.g., "MyUmbracoSite")
 - **Second argument**: Extension name (e.g., "MyExtension")
-- **Third argument** (optional): Admin email (default: `admin@test.com`)
-- **Fourth argument** (optional): Admin password (default: `SecurePass1234`)
+- **`--email`** (optional): Admin email (default: `admin@test.com`)
+- **`--password`** (optional): Admin password (default: `SecurePass1234`)
 
 If arguments not provided, check what exists and prompt for missing names.
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -138,8 +138,8 @@ These are safe for local development and don't contain special characters that c
 ```
 
 This will:
-1. Create Umbraco instance "MyUmbracoSite" (if not exists)
-2. Create extension "MyDashboard"
+1. Create Umbraco instance (e.g. "MyUmbracoSite") if not exists
+2. Create extension (e.g. "MyDashboard")
 3. Register the extension with the Umbraco project
 4. Warn about missing CMS/UUI source if applicable
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -85,27 +85,32 @@ Check extended workspace (including `/add-dir` directories) and warn if missing:
 
 ### 5. Plan what to build
 
-Once setup is complete, ask the user what they want to build:
+Once setup is complete, **enter plan mode** to help the user design their extension:
+
+1. Tell the user setup is complete and show the login credentials
+2. Ask them to describe what they want to build
+3. **Use `/plan` to enter planning mode** before creating the implementation plan
 
 ```
 ✅ Setup complete! Your extension is ready.
 
-What would you like to build? For example:
-- A custom dashboard
-- A property editor
-- A tree view in Settings
-- A content action
-- Something else?
+Login: admin@test.com / SecurePass1234
 
-I can help you plan the implementation. Just describe what you want to create.
+What would you like to build? Describe your idea and I'll help you plan the implementation.
+
+Examples:
+- "A dashboard that shows recent content changes"
+- "A property editor for picking colours"
+- "A tree in Settings for managing custom data"
 ```
 
-If the user describes what they want:
-1. Use `/umbraco-backoffice` to identify which extension types are needed
-2. Create a plan with the specific skills required
-3. Ask if they want to proceed with the implementation
+When the user describes what they want:
+1. Enter plan mode with `/plan`
+2. Use `/umbraco-backoffice` to identify which extension types are needed
+3. Create a detailed plan with the specific skills required
+4. Exit plan mode and ask if they want to proceed with implementation
 
-This turns quickstart into a complete onboarding experience - from zero to building.
+This turns quickstart into a complete onboarding experience - from zero to planning to building.
 
 ## Goal
 


### PR DESCRIPTION
- Accept [UmbracoProjectName] [ExtensionName] arguments
- Full setup: /umbraco-quickstart MyUmbracoSite MyExtension
- Partial: /umbraco-quickstart MyUmbracoSite (prompts for extension)
- No args: /umbraco-quickstart (detects or prompts)

Updated README to show new usage examples.

https://claude.ai/code/session_011725g8LKUTSq6Pg8gcdB5G