### PR TITLE
Bump plugin versions to 1.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Umbraco backoffice customization skills for Claude Code",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "homepage": "https://github.com/hifi-phil/UmbracoCMS_Skills"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umbraco-cms-backoffice-skills",
       "source": "./plugins/umbraco-backoffice-skills",
       "description": "Umbraco backoffice skills covering Foundation, Extension Types, Property Editors, Rich Text, Backend, and Setup",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",
@@ -36,7 +36,7 @@
       "name": "umbraco-cms-backoffice-testing-skills",
       "source": "./plugins/umbraco-testing-skills",
       "description": "Umbraco backoffice testing skills covering unit, MSW, mocked repo, Mocked backoffice and e2e testing using playwright",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",

--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",

--- a/plugins/umbraco-testing-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-testing-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-testing-skills",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Complete skill set for testing Umbraco backoffice extensions - Unit testing with @open-wc/testing, MSW mocking, and E2E testing with Playwright + Testhelpers",
   "author": {
     "name": "Phil W",


### PR DESCRIPTION
## Summary
This release updates the version numbers for the Umbraco Claude plugin suite from 1.0.1 to 1.0.2 across all plugin manifests and configurations.

## Changes
- Updated marketplace plugin registry (`marketplace.json`) to version 1.0.2
- Bumped umbraco-cms-backoffice-skills plugin to version 1.0.2
- Bumped umbraco-cms-backoffice-testing-skills plugin to version 1.0.2 (previously at 1.0.0)
- Updated all corresponding plugin.json configuration files with new version numbers

## Notes
- The testing skills plugin was at version 1.0.0 and is now aligned with the backoffice skills plugin at 1.0.2
- All version updates are consistent across marketplace registry and individual plugin configurations

https://claude.ai/code/session_01VdEtBQ2BTHtQHe73PHpk38