### PR TITLE
Document agent trigger conditions and validation workflow (#10)

### DIFF
--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "17.0.0-beta.1",
+  "version": "17.0.0-beta.2",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
@@ -242,3 +242,44 @@ Essential patterns used across all extensions:
 5. **Customise** the UI components for your use case
 6. **Register** with Umbraco via `umbraco-package.json`
 7. **Add project reference** to the main Umbraco instance - use skill `umbraco-add-extension-reference`
+
+---
+
+## Post-Build Review & Validation
+
+After creating or modifying an extension, trigger the following agents to ensure quality:
+
+### Agent Triggering Flow
+
+```
+Extension Built/Loaded
+        ↓
+┌───────────────────────────────────────┐
+│  AGENT: skill-quality-reviewer        │
+│  - Review code patterns               │
+│  - Fix outdated imports/types         │
+│  - Apply documentation-based fixes    │
+└───────────────────────────────────────┘
+        ↓
+Load Skills for Validation
+        ↓
+Run validate-skills
+```
+
+### Agent Summary
+
+| Agent | Purpose | Trigger Point |
+|-------|---------|---------------|
+| `umbraco-extension-reviewer` | QA review for best practices | After any umbraco-* skill generates code |
+| `skill-quality-reviewer` | Fix code patterns, imports, types | After extension build/load, before validation |
+
+### Workflow Integration
+
+When creating extensions, the recommended flow is:
+
+1. **Create extension** using appropriate skill (e.g., `umbraco-dashboard`, `umbraco-workspace`)
+2. **Spawn `umbraco-extension-reviewer`** to review generated code against best practices
+3. **Spawn `skill-quality-reviewer`** if code issues need documentation-based fixes
+4. **Run `validate-skills`** to check links, code, and tests
+
+> **TIP**: The `umbraco-extension-reviewer` agent should run automatically after any umbraco-* skill generates code. This ensures extensions follow Umbraco's architecture and best practices.

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: umbraco-review-checks
+description: Review checks reference for validating Umbraco backoffice extensions
+version: 1.0.0
+location: managed
+allowed-tools: Read
+---
+
+# Umbraco Extension Review Checks
+
+Reference skill containing all review checks for the `umbraco-extension-reviewer` agent.
+
+## Check Categories
+
+| Category | File | Checks |
+|----------|------|--------|
+| Code Quality | `code-quality-checks.md` | CQ-1 to CQ-8 |
+| Architecture | `architecture-checks.md` | AR-1 to AR-6 |
+| UI Patterns | `ui-pattern-checks.md` | UI-1 to UI-7 |
+
+## Quick Reference
+
+| ID | Check | Severity | Auto-Fix |
+|----|-------|----------|----------|
+| **Code Quality** ||||
+| CQ-1 | Extension Type Usage | Critical | Yes |
+| CQ-2 | Manifest Registration | High | No |
+| CQ-3 | Element Implementation | Medium | Partial |
+| CQ-4 | Context API Usage | High | No |
+| CQ-5 | State Management | Medium | No |
+| CQ-6 | Localization | Medium | Partial |
+| CQ-7 | Naming Conventions | Low | No |
+| CQ-8 | Conditions | Low | No |
+| **Architecture** ||||
+| AR-1 | Direct API Client Access | High | No |
+| AR-2 | No Workspace Context | High | No |
+| AR-3 | Source Pattern Verification | Medium | No |
+| AR-4 | Inconsistent Persistence | Medium | No |
+| AR-5 | Missing Repository Layer | High | No |
+| AR-6 | Circular Context Dependencies | Critical | No |
+| **UI Patterns** ||||
+| UI-1 | Custom Error Handling | High | Partial |
+| UI-2 | Layout Component Issues | High | No |
+| UI-3 | Non-UUI Component Usage | Medium | Partial |
+| UI-4 | Enum/Select Handling | Medium | Partial |
+| UI-5 | Missing Loading States | Low | No |
+| UI-6 | Accessibility Issues | Medium | No |
+| UI-7 | Inline Styles | Low | Partial |
+
+## Usage
+
+Read the relevant category file(s) based on extension type:
+
+| Extension Type | Load Files |
+|---------------|------------|
+| Dashboard | All three |
+| Workspace | All three |
+| Property Editor | code-quality, ui-pattern |
+| Entity Action | code-quality only |
+| Context/Repository | code-quality, architecture |
+
+## Related Skills
+
+| Pattern Area | Skill |
+|--------------|-------|
+| Repository pattern | `umbraco-repository-pattern` |
+| Workspace context | `umbraco-workspace` |
+| Notifications | `umbraco-notifications` |
+| Context API | `umbraco-context-api` |
+| Localization | `umbraco-localization` |
+
+## Source References
+
+### UUI Library
+
+For UI pattern checks, refer to the UUI (Umbraco UI) library for component best practices.
+
+**Check locally first** - The UUI source may be available in the workspace (e.g., `Umbraco.UI/packages/`). Use Glob to search for it.
+
+**Online resources:**
+- Storybook: https://uui.umbraco.com/
+- GitHub: https://github.com/umbraco/Umbraco.UI
+
+### Umbraco CMS Source
+
+For architecture and pattern checks, compare against Umbraco CMS source implementations.
+
+**Check locally first** - The Umbraco CMS source may be available in the workspace (e.g., `Umbraco-CMS/src/Umbraco.Web.UI.Client/`). Use Glob to search for reference implementations.
+
+**Online resources:**
+- GitHub: https://github.com/umbraco/Umbraco-CMS
+
+When reviewing, prefer local source over web fetches for accuracy and speed.

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/architecture-checks.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/architecture-checks.md
@@ -1,0 +1,154 @@
+# Architecture Checks
+
+## AR-1: Direct API Client Access
+
+**Severity:** High | **Auto-Fix:** No
+
+UI elements should not call API services directly. Use the repository pattern.
+
+```typescript
+// BAD - Direct API call in UI element
+export class MyDashboardElement extends UmbLitElement {
+  async connectedCallback() {
+    const response = await MyService.getAll();
+    this._items = response.data;
+  }
+}
+
+// GOOD - Using repository via context
+export class MyDashboardElement extends UmbLitElement {
+  constructor() {
+    super();
+    this.consumeContext(MY_WORKSPACE_CONTEXT, (context) => {
+      this.#workspaceContext = context;
+      this.observe(context.items, (items) => { this._items = items; });
+    });
+  }
+}
+```
+
+**Detection:** `*Service.get*()`, `tryExecute()`, `tryExecuteAndNotify()` in `.element.ts` files
+
+**Reference:** `umbraco-repository-pattern` skill
+
+---
+
+## AR-2: No Workspace Context
+
+**Severity:** High | **Auto-Fix:** No
+
+Workspace elements must use workspace context for data management.
+
+```typescript
+// BAD - Data loading directly in element
+export class MyWorkspaceElement extends UmbLitElement {
+  async connectedCallback() {
+    const id = this.getRouteParam('id');
+    this._data = await this.#repository.get(id);
+  }
+}
+
+// GOOD - Using workspace context
+export class MyWorkspaceElement extends UmbLitElement {
+  constructor() {
+    super();
+    this.consumeContext(MY_WORKSPACE_CONTEXT, (context) => {
+      this.#workspaceContext = context;
+      this.observe(context.data, (data) => { this._data = data; });
+    });
+  }
+}
+```
+
+**Detection:** Data loading in element `connectedCallback`, save handlers in elements
+
+**Reference:** `umbraco-workspace` skill
+
+---
+
+## AR-3: Source Pattern Verification
+
+**Severity:** Medium | **Auto-Fix:** No
+
+Extensions should follow patterns established in Umbraco source code.
+
+| Extension Type | Reference Pattern |
+|----------------|-------------------|
+| Dashboard | `src/packages/*/dashboards/` |
+| Property Editor | `src/packages/*/property-editors/` |
+| Workspace | `src/packages/*/workspace/` |
+| Collection | `src/packages/*/collection/` |
+| Tree | `src/packages/*/tree/` |
+
+**Detection:** Compare file structure, class hierarchy, manifest structure against core
+
+---
+
+## AR-4: Inconsistent Persistence
+
+**Severity:** Medium | **Auto-Fix:** No
+
+Save/persistence patterns should follow Umbraco conventions.
+
+```typescript
+// BAD - Save in wrong location
+render() {
+  return html`
+    <uui-button @click=${() => this.#repository.save(this._data)}>Save</uui-button>
+  `;
+}
+
+// GOOD - Workspace context handles persistence
+async #handleSubmit() {
+  await this.#workspaceContext.submit();
+}
+```
+
+**Detection:** Direct repository calls in render methods, missing error handling after save
+
+---
+
+## AR-5: Missing Repository Layer
+
+**Severity:** High | **Auto-Fix:** No
+
+Extensions with data persistence should implement the repository pattern.
+
+```typescript
+// BAD - Direct service usage
+export class MyFeature {
+  async getData() {
+    return await MyDataService.get();
+  }
+}
+
+// GOOD - Repository layer
+export class MyDataRepository extends UmbControllerBase {
+  async requestById(id: string) {
+    return this.#source.get(id);
+  }
+}
+```
+
+**Detection:** Direct service calls without repository wrapper
+
+**Reference:** `umbraco-repository-pattern` skill
+
+---
+
+## AR-6: Circular Context Dependencies
+
+**Severity:** Critical | **Auto-Fix:** No
+
+Context dependencies must not form cycles.
+
+```typescript
+// BAD - Circular dependency
+// context-a.ts
+consumeContext(CONTEXT_B, (b) => { ... });
+
+// context-b.ts
+consumeContext(CONTEXT_A, (a) => { ... });
+```
+
+**Detection:** Map context consume relationships, detect cycles

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/code-quality-checks.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/code-quality-checks.md
@@ -1,0 +1,175 @@
+# Code Quality Checks
+
+## CQ-1: Extension Type Usage
+
+**Severity:** Critical | **Auto-Fix:** Yes
+
+Extensions must use proper Umbraco types, not generic Lit/Web Component patterns.
+
+```typescript
+// BAD
+@customElement('my-element')
+export class MyElement extends LitElement { }
+
+// GOOD
+@customElement('my-element')
+export class MyElement extends UmbLitElement { }
+```
+
+**Detection:** Elements extending `LitElement` instead of `UmbLitElement`
+
+**Auto-Fix:** Replace `LitElement` with `UmbLitElement`, add import from `@umbraco-cms/backoffice/lit-element`
+
+---
+
+## CQ-2: Manifest Registration
+
+**Severity:** High | **Auto-Fix:** No
+
+Extensions must be properly registered in manifests.
+
+```typescript
+// BAD - No manifest registration
+export class MyDashboard extends UmbLitElement { }
+
+// GOOD - Registered in manifest
+export const manifests: Array<ManifestDashboard> = [
+  {
+    type: 'dashboard',
+    alias: 'My.Dashboard',
+    name: 'My Dashboard',
+    element: () => import('./my-dashboard.element.js'),
+  }
+];
+```
+
+**Detection:** Elements without corresponding manifest entries
+
+**Reference:** `umbraco-dashboard`, `umbraco-workspace` skills
+
+---
+
+## CQ-3: Element Implementation
+
+**Severity:** Medium | **Auto-Fix:** Partial
+
+Elements must follow Umbraco patterns for lifecycle and rendering.
+
+```typescript
+// BAD - Direct property manipulation
+this.data = newData;
+
+// GOOD - Reactive property
+@state()
+private _data?: MyData;
+```
+
+**Detection:** Missing `@state()` or `@property()` decorators on reactive properties
+
+**Auto-Fix:** Add `@state()` decorator to private reactive properties
+
+---
+
+## CQ-4: Context API Usage
+
+**Severity:** High | **Auto-Fix:** No
+
+Extensions must use Context API for shared state and services.
+
+```typescript
+// BAD - Direct service instantiation
+const service = new MyService();
+
+// GOOD - Context consumption
+this.consumeContext(UMB_NOTIFICATION_CONTEXT, (context) => {
+  this._notificationContext = context;
+});
+```
+
+**Detection:** Direct service instantiation instead of context consumption
+
+**Reference:** `umbraco-context-api` skill
+
+---
+
+## CQ-5: State Management
+
+**Severity:** Medium | **Auto-Fix:** No
+
+State must be managed reactively using Umbraco patterns.
+
+```typescript
+// BAD - Manual state updates
+this.items = await this.fetchItems();
+this.requestUpdate();
+
+// GOOD - Observable state
+this.observe(
+  this._workspaceContext.data,
+  (data) => { this._data = data; }
+);
+```
+
+**Detection:** Manual `requestUpdate()` calls, missing `observe()` usage
+
+**Reference:** `umbraco-state-management` skill
+
+---
+
+## CQ-6: Localization
+
+**Severity:** Medium | **Auto-Fix:** Partial
+
+User-facing text must use localization.
+
+```typescript
+// BAD - Hardcoded strings
+html`<uui-button>Save</uui-button>`
+
+// GOOD - Localized
+html`<uui-button><umb-localize key="general_save"></umb-localize></uui-button>`
+```
+
+**Detection:** Hardcoded user-facing strings in templates
+
+**Auto-Fix:** Wrap known strings with `<umb-localize>` for common terms
+
+**Reference:** `umbraco-localization` skill
+
+---
+
+## CQ-7: Naming Conventions
+
+**Severity:** Low | **Auto-Fix:** No
+
+Extensions must follow Umbraco naming conventions.
+
+| Type | File Pattern | Class Pattern | Alias Pattern |
+|------|--------------|---------------|---------------|
+| Element | `*.element.ts` | `*Element` | - |
+| Context | `*.context.ts` | `*Context` | - |
+| Controller | `*.controller.ts` | `*Controller` | - |
+| Repository | `*.repository.ts` | `*Repository` | - |
+| Manifest | `manifests.ts` | - | `Vendor.Name` |
+
+**Detection:** Files/classes not following naming patterns
+
+---
+
+## CQ-8: Conditions
+
+**Severity:** Low | **Auto-Fix:** No
+
+Extensions using conditions must reference valid condition types.
+
+```typescript
+// BAD - Invalid condition
+conditions: [{ alias: 'Umb.Condition.DoesNotExist' }]
+
+// GOOD - Valid condition
+conditions: [{ alias: 'Umb.Condition.SectionUserPermission' }]
+```
+
+**Detection:** Unknown condition aliases in manifests
+
+**Reference:** `umbraco-conditions` skill

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/ui-pattern-checks.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/ui-pattern-checks.md
@@ -1,0 +1,189 @@
+# UI Pattern Checks
+
+## UI-1: Custom Error Handling
+
+**Severity:** High | **Auto-Fix:** Partial
+
+Use Umbraco notification system, not browser alerts or custom error divs.
+
+```typescript
+// BAD
+alert('Something went wrong!');
+html`<div class="error">${this._errorMessage}</div>`
+
+// GOOD
+this._notificationContext?.peek('danger', {
+  data: { message: 'Something went wrong!' }
+});
+```
+
+**Detection:** `alert()`, `window.alert()`, custom error divs/spans
+
+**Auto-Fix:** Replace simple `alert()` calls with notification context (requires context to be consumed)
+
+**Reference:** `umbraco-notifications` skill
+
+---
+
+## UI-2: Layout Component Issues
+
+**Severity:** High | **Auto-Fix:** No
+
+Workspace elements should use `<umb-workspace-editor>` for proper layout.
+
+```typescript
+// BAD - Save button in content area
+render() {
+  return html`
+    <div>
+      <form>...</form>
+      <uui-button @click=${this.#save}>Save</uui-button>
+    </div>
+  `;
+}
+
+// GOOD - Using workspace editor
+render() {
+  return html`
+    <umb-workspace-editor alias="My.Workspace">
+      <!-- content goes here -->
+    </umb-workspace-editor>
+  `;
+}
+```
+
+**Detection:** Save buttons outside workspace editor, custom header/footer implementations
+
+**Reference:** `umbraco-workspace` skill
+
+---
+
+## UI-3: Non-UUI Component Usage
+
+**Severity:** Medium | **Auto-Fix:** Partial
+
+Use UUI components instead of native HTML elements.
+
+| Native HTML | UUI Replacement |
+|-------------|-----------------|
+| `<button>` | `<uui-button>` |
+| `<input type="text">` | `<uui-input>` |
+| `<input type="checkbox">` | `<uui-checkbox>` |
+| `<select>` | `<uui-select>` or `<uui-combobox>` |
+| `<textarea>` | `<uui-textarea>` |
+| `<table>` | `<uui-table>` |
+| `<dialog>` | Use Umbraco modal system |
+
+**Detection:** Native form elements in templates
+
+**Auto-Fix:** Suggest UUI replacements (binding syntax may differ)
+
+---
+
+## UI-4: Enum/Select Handling
+
+**Severity:** Medium | **Auto-Fix:** Partial
+
+Enums must be properly handled on both backend and frontend.
+
+**Backend (C#):**
+```csharp
+// BAD - Enum serializes as integer
+public MyEnum Status { get; set; }
+
+// GOOD - Enum serializes as string
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public MyEnum Status { get; set; }
+```
+
+**Frontend (TypeScript):**
+```typescript
+// BAD - Native select
+html`<select><option value="draft">Draft</option></select>`
+
+// GOOD - UUI select
+html`<uui-select .options=${[{ name: 'Draft', value: 'draft' }]}></uui-select>`
+```
+
+**Detection:** Enum properties without `JsonStringEnumConverter`, native `<select>` elements
+
+---
+
+## UI-5: Missing Loading States
+
+**Severity:** Low | **Auto-Fix:** No
+
+Async operations should show loading indicators.
+
+```typescript
+// BAD - No loading state
+async connectedCallback() {
+  this._data = await this.#loadData();
+}
+
+// GOOD - Loading state
+@state() private _loading = true;
+
+async connectedCallback() {
+  this._loading = true;
+  this._data = await this.#loadData();
+  this._loading = false;
+}
+
+render() {
+  if (this._loading) return html`<uui-loader></uui-loader>`;
+  return html`<div>${this._data?.name}</div>`;
+}
+```
+
+**Detection:** Async data loading without loading state
+
+---
+
+## UI-6: Accessibility Issues
+
+**Severity:** Medium | **Auto-Fix:** No
+
+Extensions must be accessible.
+
+```typescript
+// BAD - Missing labels
+html`<uui-input .value=${this._value}></uui-input>`
+
+// BAD - Non-interactive element with click
+html`<div @click=${this.#handleClick}>Click me</div>`
+
+// GOOD
+html`
+  <uui-label for="my-input">Name</uui-label>
+  <uui-input id="my-input" .value=${this._value}></uui-input>
+`
+```
+
+**Detection:** Form inputs without labels, click handlers on non-interactive elements
+
+---
+
+## UI-7: Inline Styles
+
+**Severity:** Low | **Auto-Fix:** Partial
+
+Avoid inline styles; use CSS classes or UUI styling.
+
+```typescript
+// BAD
+html`<div style="color: red; margin: 10px;">Error</div>`
+
+// GOOD
+static styles = css`
+  .error { color: var(--uui-color-danger); }
+`;
+
+render() {
+  return html`<div class="error">Error</div>`;
+}
+```
+
+**Detection:** `style="..."` attributes in templates
+
+**Auto-Fix:** Extract inline styles to static styles block

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: umbraco-validation-checks
+description: Browser validation checks for testing Umbraco backoffice extensions manually
+version: 1.0.0
+location: managed
+allowed-tools: Read
+---
+
+# Umbraco Extension Validation Checks
+
+Reference skill containing validation checks for manual browser testing of Umbraco backoffice extensions. Load this skill before beginning validation testing.
+
+## Check Categories
+
+| Category | File | Checks |
+|----------|------|--------|
+| Configuration | `configuration-checks.md` | VC-1 to VC-2 |
+| Navigation | `navigation-checks.md` | VN-1 to VN-3 |
+| API Debugging | `api-debugging-checks.md` | VA-1 to VA-3 |
+| Form Controls | `form-control-checks.md` | VF-1 to VF-2 |
+
+## Quick Reference
+
+| ID | Check | Common Symptom |
+|----|-------|----------------|
+| **Configuration** |||
+| VC-1 | Section Permissions | New section not visible |
+| VC-2 | User Group Access | Extension appears for some users only |
+| **Navigation** |||
+| VN-1 | Tree Complexity | Tree not rendering or items missing |
+| VN-2 | Hidden Tree Actions | Cannot find expected button/action |
+| VN-3 | Menu Item Visibility | Menu items not appearing |
+| **API Debugging** |||
+| VA-1 | 400 Error Investigation | API calls failing silently |
+| VA-2 | Request Payload Validation | Wrong data structure being sent |
+| VA-3 | CORS and Auth Issues | Requests blocked or unauthorized |
+| **Form Controls** |||
+| VF-1 | Select/Combobox Behavior | Select not populating and causing 400 errors |
+| VF-2 | Input Binding Issues | Values not updating or saving |
+
+## Usage
+
+**Always load this skill before starting manual browser validation.**
+
+Read all check files when validating a new extension, or focus on specific categories based on the symptoms you observe.
+
+| Symptom | Load Files |
+|---------|------------|
+| "Can't see my extension" | configuration-checks, navigation-checks |
+| "API not working" | api-debugging-checks |
+| "Form doesn't work" | form-control-checks |
+| "Tree issues" | navigation-checks |
+
+## Validation Workflow
+
+1. **Before testing**: Ensure the extension is built and the browser cache is cleared
+2. **Check DevTools Console**: Open Chrome DevTools (F12) before interacting
+3. **Check Network tab**: Filter by `Fetch/XHR` to see API calls
+4. **Read relevant check files** based on what you observe
+
+## Capturing New Issues
+
+When you encounter a validation issue not covered by existing checks:
+
+1. **Log it immediately** in `discovered-issues.md`
+2. Include: symptom, root cause, solution, suggested category
+3. Issues will be reviewed and promoted to proper checks
+
+This compounds knowledge over time - every validation session improves future sessions.
+
+## Related Skills
+
+| Pattern Area | Skill |
+|--------------|-------|
+| Tree implementation | `umbraco-tree` |
+| Section setup | `umbraco-sections` |
+| API client setup | `umbraco-openapi-client` |
+| Workspace structure | `umbraco-workspace` |

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/api-debugging-checks.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/api-debugging-checks.md
@@ -1,0 +1,110 @@
+# API Debugging Checks
+
+## VA-1: 400 Error Investigation
+
+**Common Symptom:** API calls failing, often silently or with generic errors
+
+**ALWAYS check for 400 (Bad Request) errors first.** These indicate the data sent to the server is wrong.
+
+**How to investigate:**
+
+1. Open Chrome DevTools (F12)
+2. Go to **Network** tab
+3. Filter by **Fetch/XHR**
+4. Look for requests with **red status** (400, 401, 403, 404, 500)
+5. Click the failed request
+6. Check **Response** tab for error details
+
+**Before deep-diving into 400 errors:** Check all form selects/dropdowns first. Empty or broken selects are a common cause of 400 errors that leads to circular debugging. See **VF-1: Select/Combobox Behavior**.
+
+**400 errors usually mean:**
+
+| Error Pattern | Likely Cause |
+|---------------|--------------|
+| "Validation failed" | Required field missing or wrong type |
+| "Invalid property" | Property name doesn't match backend model |
+| "Cannot deserialize" | Wrong data structure (array vs object, string vs number) |
+| Empty response body | Check Request payload - likely malformed |
+
+**Debug checklist for 400 errors:**
+
+- [ ] Check **Request** tab > **Payload** - is the data correct?
+- [ ] Compare payload structure to backend model/DTO
+- [ ] Check for `null` values where object expected
+- [ ] Check for string where number expected (and vice versa)
+- [ ] Verify enum values are strings (if using `JsonStringEnumConverter`)
+
+---
+
+## VA-2: Request Payload Validation
+
+**Common Symptom:** Data appears correct in UI but API rejects it
+
+**Check the actual payload being sent:**
+
+1. Network tab > Click failed request > **Payload** tab
+2. Compare against what the backend expects
+
+**Common payload issues:**
+
+| Issue | What to Look For |
+|-------|------------------|
+| Wrong property names | Backend uses `camelCase`, frontend sending `PascalCase` |
+| Missing required fields | Check backend model for `[Required]` attributes |
+| Wrong ID format | GUIDs should be lowercase with dashes |
+| Enum as number | Should be string if backend uses `JsonStringEnumConverter` |
+| Nested object null | Parent object exists but child is `null` |
+
+**Example - verifying GUID format:**
+
+```typescript
+// WRONG - uppercase or no dashes
+const id = "A1B2C3D4E5F6";
+
+// CORRECT - lowercase with dashes
+const id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+```
+
+**Example - verifying enum as string:**
+
+```typescript
+// WRONG - sending number
+{ status: 0 }
+
+// CORRECT - sending string (if backend has JsonStringEnumConverter)
+{ status: "Draft" }
+```
+
+---
+
+## VA-3: CORS and Auth Issues
+
+**Common Symptom:** Requests blocked or returning 401/403
+
+**401 Unauthorized:**
+
+- Token expired - try refreshing the page
+- API requires authentication but OpenAPI client not configured
+- Check `umbraco-openapi-client` skill for proper setup
+
+**403 Forbidden:**
+
+- User doesn't have permission for this action
+- Check user group permissions
+
+**CORS errors (visible in Console):**
+
+- API endpoint doesn't allow cross-origin requests
+- Usually indicates wrong API URL or missing CORS configuration on backend
+
+**Debug checklist:**
+
+- [ ] Is there a CORS error in the Console?
+- [ ] Check request headers - is Authorization header present?
+- [ ] For custom APIs, verify OpenAPI client is configured
+- [ ] Try refreshing the page to get new auth token
+- [ ] Check if API endpoint is correct (no typos in URL)
+
+**If using custom API controllers:**
+
+Ensure the controller inherits from the correct base class and has proper authorization attributes. See `umbraco-openapi-client` skill for proper setup.

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/configuration-checks.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/configuration-checks.md
@@ -1,0 +1,65 @@
+# Configuration Checks
+
+## VC-1: Section Permissions
+
+**Common Symptom:** New section not visible in the backoffice sidebar
+
+When creating a new section, it won't appear unless the user's group has permission to access it.
+
+**Before testing a new section:**
+
+1. Go to **Users** > **User Groups** > **Administrators**
+2. Scroll to **Sections** (or "Allowed Sections")
+3. Ensure your new section is checked/enabled
+4. Save the user group
+5. **Refresh the page** (Ctrl+Shift+R / Cmd+Shift+R)
+
+**Why this happens:** Umbraco's permission system hides sections by default. Even the admin user needs explicit group permission to see new sections.
+
+**Code verification:** Check if the section manifest is registered:
+
+```typescript
+// Should be in umbraco-package.json or registered via entry point
+{
+  type: 'section',
+  alias: 'My.Section',
+  name: 'My Section',
+  meta: {
+    label: 'My Section',
+    pathname: 'my-section'
+  }
+}
+```
+
+---
+
+## VC-2: User Group Access
+
+**Common Symptom:** Extension works for one user but not another
+
+Different user groups have different permissions. When validating:
+
+1. **Test with the admin account first** - this has the most permissions
+2. If it works for admin but not other users, it's a permissions issue
+3. Check the specific user group's allowed sections and permissions
+
+**Debug checklist:**
+
+- [ ] Is the user logged in with the correct account?
+- [ ] Does the user's group have access to the section?
+- [ ] Are there any `conditions` on the extension that might filter by user role?
+
+**Example condition that limits access:**
+
+```typescript
+{
+  type: 'dashboard',
+  alias: 'My.Dashboard',
+  conditions: [
+    {
+      alias: 'Umb.Condition.SectionAlias',
+      match: 'My.Section'  // Only shows when in this section
+    }
+  ]
+}
+```

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/discovered-issues.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/discovered-issues.md
@@ -1,0 +1,24 @@
+# Discovered Issues Log
+
+Log new validation issues here as they are discovered. These will be reviewed and incorporated into the appropriate check files.
+
+## Format
+
+When logging a new issue, include:
+
+```markdown
+### [Date] Brief title
+
+**Symptom:** What you observed
+**Root cause:** What was actually wrong
+**Solution:** How to fix/avoid it
+**Suggested category:** (configuration | navigation | api-debugging | form-control | new)
+```
+
+---
+
+## Pending Issues
+
+<!-- Add new discovered issues below this line -->
+
+

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/form-control-checks.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/form-control-checks.md
@@ -1,0 +1,134 @@
+# Form Control Checks
+
+## VF-1: Select/Combobox Behavior
+
+**Common Symptom:** Dropdown not working, wrong value selected, or options not appearing
+
+> **Key insight:** Empty or broken selects are a common cause of mysterious 400 API errors. When debugging 400 errors, **always check selects first** - if a select has no data or wrong data, the form submits invalid values that the API rejects.
+
+**The select → 400 error trap:**
+
+1. Select component renders but has no options (data didn't load)
+2. User fills out form, select value is `null` or `undefined`
+3. Form submits, API returns 400
+4. Developer checks API payload, sees missing/wrong value
+5. Goes in circles checking API, models, etc.
+6. **Root cause was the select never populated**
+
+**Before debugging 400 errors, check all selects:**
+
+- [ ] Does the dropdown show options when clicked?
+- [ ] Is the correct option selected?
+- [ ] In DevTools Elements tab, inspect the select - does it have a value?
+
+**UUI Select vs Combobox:**
+
+| Component | Use Case |
+|-----------|----------|
+| `uui-select` | Simple dropdowns with predefined options |
+| `uui-combobox` | Searchable/filterable dropdowns, typeahead |
+
+**Common select issues:**
+
+| Issue | Likely Cause |
+|-------|--------------|
+| Options don't appear | Options array is empty or malformed |
+| Wrong item selected | Value binding uses wrong property |
+| Selection doesn't persist | Event handler not updating state |
+| Shows "[object Object]" | Display property not specified |
+
+**Verify options format:**
+
+```typescript
+// uui-select expects this format
+const options = [
+  { name: 'Display Text', value: 'actual-value' },
+  { name: 'Another Option', value: 'another-value' }
+];
+
+// In template
+html`<uui-select .options=${this._options} @change=${this.#onChange}></uui-select>`
+```
+
+**Debug checklist for selects:**
+
+- [ ] Check Console - any errors when clicking dropdown?
+- [ ] Verify options array is populated (add `console.log` temporarily)
+- [ ] Check `name` and `value` properties in options
+- [ ] Verify change event handler is being called
+- [ ] Check if value is being set correctly (`.value` vs `value` attribute)
+
+**Property binding matters:**
+
+```typescript
+// WRONG - attribute binding for objects
+<uui-select options=${this._options}>
+
+// CORRECT - property binding with dot prefix
+<uui-select .options=${this._options}>
+```
+
+---
+
+## VF-2: Input Binding Issues
+
+**Common Symptom:** Values not updating, not saving, or reverting
+
+**Check binding direction:**
+
+| Syntax | Direction | Use For |
+|--------|-----------|---------|
+| `.value=${x}` | JS to DOM | Setting input value |
+| `@input=${fn}` | DOM to JS | Reacting to typing |
+| `@change=${fn}` | DOM to JS | Reacting to value commit |
+
+**Common input issues:**
+
+| Issue | Likely Cause |
+|-------|--------------|
+| Value doesn't update | Missing `.` in property binding |
+| Changes lost on re-render | State not being updated in event handler |
+| Value reverts after typing | Two-way binding not implemented |
+| Saves wrong value | Reading wrong property from event |
+
+**Correct two-way binding pattern:**
+
+```typescript
+@state() private _name = '';
+
+#onNameInput(e: UUIInputEvent) {
+  this._name = e.target.value as string;
+}
+
+render() {
+  return html`
+    <uui-input
+      .value=${this._name}
+      @input=${this.#onNameInput}>
+    </uui-input>
+  `;
+}
+```
+
+**Debug checklist for inputs:**
+
+- [ ] Is the value property bound with dot prefix (`.value`)?
+- [ ] Is there an event handler for `@input` or `@change`?
+- [ ] Does the event handler update component state?
+- [ ] Is the state decorated with `@state()`?
+- [ ] Check event target - is it the input element or a wrapper?
+
+**Getting value from event:**
+
+```typescript
+// For UUI components
+#onInput(e: UUIInputEvent) {
+  const value = e.target.value;  // Usually works
+}
+
+// If nested or wrapped, may need to cast
+#onInput(e: Event) {
+  const target = e.target as UUIInputElement;
+  const value = target.value;
+}
+```

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/navigation-checks.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-validation-checks/navigation-checks.md
@@ -1,0 +1,104 @@
+# Navigation Checks
+
+## VN-1: Tree Complexity
+
+**Common Symptom:** Tree not rendering, items missing, or incorrect hierarchy
+
+Trees in Umbraco are complex multi-part systems. When trees don't work:
+
+**ALWAYS check these reference implementations first:**
+
+1. **Use the `umbraco-tree` skill** - contains working examples
+2. **Look at the notes-wiki example** if available in your project
+3. **Check Umbraco CMS source** for reference tree implementations
+
+**Tree requires multiple parts:**
+
+| Part | Purpose |
+|------|---------|
+| Tree manifest | Registers the tree |
+| Tree repository | Provides data to the tree |
+| Tree store | Caches tree data |
+| Tree item manifest | Renders individual items |
+| Entity actions | Context menu items |
+
+**Common tree issues:**
+
+| Issue | Likely Cause |
+|-------|--------------|
+| Tree doesn't appear | Missing tree manifest or wrong section alias |
+| Items don't load | Repository not returning correct data structure |
+| Can't expand items | `hasChildren` not set correctly |
+| No context menu | Entity actions not registered for this entity type |
+
+**Debug steps:**
+
+1. Check Console for errors when clicking tree
+2. Check Network tab - is the API being called?
+3. Verify tree alias matches in all related manifests
+
+---
+
+## VN-2: Hidden Tree Actions
+
+**Common Symptom:** Cannot find expected button or action
+
+**Buttons and actions can be in several places:**
+
+| Location | How to Access |
+|----------|---------------|
+| Tree context menu | **Right-click** on tree item |
+| Tree item actions | Look for **"..."** (three dots) button on tree item row |
+| Workspace header | Actions bar at top of workspace |
+| Entity actions tray | Expandable tray (often bottom or side) |
+
+**If you can't find a button:**
+
+1. **Right-click the tree item** - context menu may have the action
+2. **Hover over tree items** - action buttons may appear on hover
+3. **Look for "..." or kebab menu** on the tree item row
+4. **Check workspace header** if you've opened an item
+5. **Scroll the workspace** - action bars can be at bottom
+
+**Tree actions vs Entity actions:**
+
+- **Tree actions**: Appear in tree context menu
+- **Entity actions**: Appear in workspace header or action tray
+- **Collection actions**: Appear in collection/list view toolbar
+
+---
+
+## VN-3: Menu Item Visibility
+
+**Common Symptom:** Menu items not appearing where expected
+
+Menu items require:
+
+1. **Correct `menus` array** in manifest
+2. **Section must be visible** to user
+3. **Any conditions must be satisfied**
+
+**Check the manifest:**
+
+```typescript
+{
+  type: 'menuItem',
+  alias: 'My.MenuItem',
+  name: 'My Menu Item',
+  menus: ['Umb.Menu.StructureSettings'],  // Must match existing menu
+  meta: {
+    label: 'My Item',
+    icon: 'icon-settings'
+  }
+}
+```
+
+**Common menu aliases:**
+
+| Menu | Alias |
+|------|-------|
+| Settings structure | `Umb.Menu.StructureSettings` |
+| Content menu | `Umb.Menu.Content` |
+| Media menu | `Umb.Menu.Media` |
+
+If menu item doesn't appear, verify the menu alias is correct and the user has access to the parent section.


### PR DESCRIPTION
* Add agent trigger references and pre-validation skill loading

- Add Pre-Validation section with agent triggering flow diagram
- Add Phase 0 for loading skills before validation begins
- Update skill-quality-reviewer with primary trigger after extension build/load
- Update skill-content-fixer with trigger after validation finds link issues
- Add detailed Agent Lifecycle section with spawn instructions
- Add Post-Build/Load Flow for integration with extension creation
- Document workflow position for both reviewing agents

https://claude.ai/code/session_01MDEir3TCMQSszz1mfeou1H

* Convert validate-skills to skill and add agent triggers to backoffice

- Revert trigger condition changes from agent files (keep agents generic)
- Convert validate-skills from command to skill at .claude/skills/validate-skills/
- Add Post-Build Review & Validation section to umbraco-backoffice SKILL.md
- Document agent triggering flow in backoffice skill definition
- Update umbraco-skill-validator to reference skill instead of command

Agent triggers now defined where they're used (backoffice skill) rather than in the agents themselves, keeping agents reusable.

https://claude.ai/code/session_01MDEir3TCMQSszz1mfeou1H

* Clarify agent labels in triggering flow diagram

Add "AGENT:" prefix to skill-quality-reviewer and skill-content-fixer in the flow diagram to make it explicit these are agents being spawned.

https://claude.ai/code/session_01MDEir3TCMQSszz1mfeou1H

* Remove skill-content-fixer from backoffice skill references

skill-content-fixer is internal to the validation process and should not be referenced in the backoffice skill definition.

https://claude.ai/code/session_01MDEir3TCMQSszz1mfeou1H

* Revert .claude/skills changes, restore validate-skills command

- Restore original .claude/commands/validate-skills.md
- Revert changes to .claude/skills/umbraco-skill-validator/SKILL.md
- Remove .claude/skills/validate-skills/ directory

The validate-skills remains a command, not a skill. Agent trigger references are only in the backoffice skill definition.

https://claude.ai/code/session_01MDEir3TCMQSszz1mfeou1H

---------