### PR TITLE
Embed workflow practices into skills system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Umbraco backoffice customization skills for Claude Code",
-    "version": "17.0.0-beta.1",
+    "version": "17.0.0-beta.4",
     "homepage": "https://github.com/hifi-phil/UmbracoCMS_Skills"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umbraco-cms-backoffice-skills",
       "source": "./plugins/umbraco-backoffice-skills",
       "description": "Umbraco backoffice skills covering Foundation, Extension Types, Property Editors, Rich Text, Backend, and Setup",
-      "version": "17.0.0-beta.1",
+      "version": "17.0.0-beta.4",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",

--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "17.0.0-beta.3",
+  "version": "17.0.0-beta.4",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/EXTENSION-MAP.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/EXTENSION-MAP.md
@@ -1,0 +1,87 @@
+# Backoffice Extension Map
+
+This diagram shows where ALL extension types appear in the Umbraco backoffice UI.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│ HEADER BAR                                                                       │
+│ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐           ┌───────────────────┐ │
+│ │ Content │ │  Media  │ │Settings │ │ Section │  ...      │    Header Apps    │ │
+│ │         │ │         │ │         │ │  ****   │           │ (umbraco-header-  │ │
+│ │         │ │         │ │         │ │         │           │     apps)         │ │
+│ └─────────┘ └─────────┘ └─────────┘ └─────────┘           └───────────────────┘ │
+│      ^                        ^                                    ^            │
+│      │                        │                                    │            │
+│  (umbraco-sections)      Your Section                    User menu, search,     │
+│                                                          notifications          │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│ SIDEBAR                    │  MAIN CONTENT AREA                                 │
+│ ┌────────────────────────┐ │ ┌─────────────────────────────────────────────────┐│
+│ │ SectionSidebarApp      │ │ │ Dashboard (umbraco-dashboard)                   ││
+│ │ (part of sections)     │ │ │ Shows when nothing selected in tree             ││
+│ │                        │ │ │ ┌─────────────────────────────────────────────┐ ││
+│ │ ┌────────────────────┐ │ │ │ │ Your welcome content, stats, quick actions │ ││
+│ │ │ Menu               │ │ │ │ └─────────────────────────────────────────────┘ ││
+│ │ │ (umbraco-menu)     │ │ │ └─────────────────────────────────────────────────┘│
+│ │ │                    │ │ │                                                    │
+│ │ │ ┌────────────────┐ │ │ │ ┌─────────────────────────────────────────────────┐│
+│ │ │ │ MenuItem       │ │ │ │ │ Workspace (umbraco-workspace)                   ││
+│ │ │ │ (umbraco-menu- │ │ │ │ │ Shows when entity selected                      ││
+│ │ │ │     items)     │ │ │ │ │ ┌─────────────────────────────────────────────┐ ││
+│ │ │ │                │ │ │ │ │ │ WorkspaceView tabs (Content, Settings...)  │ ││
+│ │ │ │ kind: "tree"───┼─┼─┼─┼─┤ │ ┌─────────┐ ┌─────────┐ ┌─────────┐       │ ││
+│ │ │ └────────────────┘ │ │ │ │ │ │ View 1  │ │ View 2  │ │ View 3  │       │ ││
+│ │ │                    │ │ │ │ │ └─────────┘ └─────────┘ └─────────┘       │ ││
+│ │ │ ┌────────────────┐ │ │ │ │ └─────────────────────────────────────────────┘ ││
+│ │ │ │ Tree           │ │ │ │ │                                                 ││
+│ │ │ │ (umbraco-tree) │ │ │ │ │ WorkspaceActions (Save, Delete...)             ││
+│ │ │ │                │ │ │ │ │ (umbraco-entity-actions)                        ││
+│ │ │ │ ├─ Folder      │ │ │ │ └─────────────────────────────────────────────────┘│
+│ │ │ │ │  └─ Item ────┼─┼─┼─┼──> entityType links to Workspace                  │
+│ │ │ │ └─ Item        │ │ │ │                                                    │
+│ │ │ │   (umbraco-    │ │ │ │ ┌─────────────────────────────────────────────────┐│
+│ │ │ │    tree-item)  │ │ │ │ │ Collection (umbraco-collection)                 ││
+│ │ │ └────────────────┘ │ │ │ │ List/grid view of items                         ││
+│ │ └────────────────────┘ │ │ │ ┌─────────────────────────────────────────────┐ ││
+│ └────────────────────────┘ │ │ │ CollectionView (umbraco-collection-view)    │ ││
+│                            │ │ │ CollectionAction (umbraco-collection-action)│ ││
+│                            │ │ └─────────────────────────────────────────────┘ ││
+│                            │ └─────────────────────────────────────────────────┘│
+├────────────────────────────┴────────────────────────────────────────────────────┤
+│ MODALS & OVERLAYS (umbraco-modals)                                              │
+│ ┌─────────────────────────────────────────────────────────────────────────────┐ │
+│ │ Pickers, confirmations, custom dialogs - appear above main content          │ │
+│ └─────────────────────────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│ PROPERTY EDITORS (in Document/Media workspaces)                                 │
+│ ┌─────────────────────────────────────────────────────────────────────────────┐ │
+│ │ PropertyEditorUI (umbraco-property-editor-ui)  - The visual editor          │ │
+│ │ PropertyEditorSchema (umbraco-property-editor-schema) - Data validation     │ │
+│ │ PropertyAction (umbraco-property-action) - Buttons on property              │ │
+│ └─────────────────────────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│ RICH TEXT EDITOR (Tiptap)                                                       │
+│ ┌─────────────────────────────────────────────────────────────────────────────┐ │
+│ │ TiptapExtension (umbraco-tiptap-extension) - Core editor behavior           │ │
+│ │ TiptapToolbarExtension (umbraco-tiptap-toolbar-extension) - Toolbar buttons │ │
+│ │ TiptapStatusbarExtension (umbraco-tiptap-statusbar-extension) - Status bar  │ │
+│ └─────────────────────────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│ GLOBAL FEATURES                                                                 │
+│ ┌─────────────────────────────────────────────────────────────────────────────┐ │
+│ │ SearchProvider (umbraco-search-provider) - Global search results            │ │
+│ │ SearchResultItem (umbraco-search-result-item) - Custom result rendering     │ │
+│ │ HealthCheck (umbraco-health-check) - Settings > Health Check                │ │
+│ │ Theme (umbraco-theme) - Custom backoffice themes                            │ │
+│ │ Icons (umbraco-icons) - Custom icon sets                                    │ │
+│ │ AuthProvider (umbraco-auth-provider) - External login buttons               │ │
+│ │ MfaLoginProvider (umbraco-mfa-login-provider) - 2FA methods                 │ │
+│ └─────────────────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## How to Use This Map
+
+- **Finding where an extension appears**: Locate the extension type in the diagram to see its position in the UI
+- **Understanding relationships**: Arrows and containment show how extensions connect (e.g., MenuItem with `kind: "tree"` links to Tree)
+- **Planning your extension**: Identify which extension types you need based on where your feature should appear

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/POST-BUILD-VALIDATION.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/POST-BUILD-VALIDATION.md
@@ -1,0 +1,154 @@
+# Post-Build Review & Validation
+
+After creating or modifying an extension, follow this complete validation workflow.
+
+## Build Verification
+
+Before any other validation, ensure the code compiles:
+
+```bash
+# In the extension project directory
+npm run build
+```
+
+**Requirements:**
+- TypeScript compiles without errors
+- No unresolved imports
+- Output files generated in `dist/` or configured output directory
+
+## Code Review (MANDATORY)
+
+**ALWAYS run the extension reviewer after generating code:**
+
+```
+Spawn agent: umbraco-extension-reviewer
+```
+
+This agent checks for:
+- Correct extension type usage
+- Proper context consumption patterns
+- Import path correctness
+- UUI component usage
+- Manifest registration
+
+### Auto-Fix Policy
+
+| Severity | Action |
+|----------|--------|
+| **High** | Fix immediately without asking |
+| **Medium** | Fix immediately without asking |
+| **Low** | Note for user, fix if straightforward |
+| **Info** | Ignore unless user requests |
+
+## Agent Triggering Flow
+
+```
+Extension Built
+        ↓
+┌───────────────────────────────────────┐
+│  Build Verification                   │
+│  - npm run build                      │
+│  - Check for TypeScript errors        │
+└───────────────────────────────────────┘
+        ↓
+┌───────────────────────────────────────┐
+│  AGENT: umbraco-extension-reviewer    │
+│  - Review code patterns               │
+│  - Check best practices               │
+│  - Auto-fix High/Medium issues        │
+└───────────────────────────────────────┘
+        ↓
+┌───────────────────────────────────────┐
+│  AGENT: skill-quality-reviewer        │
+│  - Fix outdated imports/types         │
+│  - Apply documentation-based fixes    │
+└───────────────────────────────────────┘
+        ↓
+Browser Testing
+        ↓
+Run validate-skills
+```
+
+## Agent Summary
+
+| Agent | Purpose | Trigger Point |
+|-------|---------|---------------|
+| `umbraco-extension-reviewer` | QA review for best practices | After any umbraco-* skill generates code |
+| `skill-quality-reviewer` | Fix code patterns, imports, types | After extension build/load, before validation |
+
+## Browser Testing Workflow
+
+After code review passes, test in the browser:
+
+### 1. Start Umbraco
+
+```bash
+# From Umbraco project root
+dotnet run
+```
+
+### 2. Navigate to Extension
+
+Open the backoffice and navigate to where your extension should appear.
+
+### 3. What to Verify
+
+| Check | How to Verify |
+|-------|---------------|
+| **Extension loads** | No console errors on page load |
+| **UI renders** | Visual elements appear as designed |
+| **Interactions work** | Buttons, inputs, navigation function |
+| **Data flows** | API calls succeed, data displays |
+| **Context available** | No "context not found" errors |
+
+### 4. Browser DevTools Checks
+
+Open DevTools (F12) and verify:
+
+- **Console**: No red errors related to your extension
+- **Network**: API calls return 200/successful responses
+- **Elements**: Your custom elements render in the DOM
+
+## When Tests Fail
+
+### Build Errors
+
+1. Read the error message carefully
+2. Check import paths match actual file locations
+3. Verify types are correctly imported from `@umbraco-cms/backoffice/*`
+
+### Extension Not Loading
+
+1. Check `umbraco-package.json` has correct paths
+2. Verify the extension is registered with correct alias
+3. Check browser console for manifest loading errors
+
+### Context Not Found
+
+1. Ensure parent element provides the context
+2. Check you're consuming the correct context token
+3. Verify context is available at the DOM level where you consume it
+
+### API Errors
+
+1. Check authentication - use `umbraco-openapi-client` skill
+2. Verify endpoint URL matches backend controller
+3. Check request/response payload format
+
+## Complete Workflow Summary
+
+```
+1. Create extension ──► Use appropriate umbraco-* skill
+        ↓
+2. Build ──► npm run build (must pass)
+        ↓
+3. Code review ──► Spawn umbraco-extension-reviewer (MANDATORY)
+        ↓
+4. Fix issues ──► Auto-fix High/Medium severity
+        ↓
+5. Browser test ──► Verify extension works
+        ↓
+6. Validate ──► Run validate-skills
+```
+
+> **TIP**: The `umbraco-extension-reviewer` agent should run automatically after any umbraco-* skill generates code. This ensures extensions follow Umbraco's architecture and best practices.

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/PRE-BUILD-PLANNING.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/PRE-BUILD-PLANNING.md
@@ -1,0 +1,91 @@
+# Pre-Build Planning
+
+Before building any Umbraco backoffice extension, complete these planning steps.
+
+## 1. Visual Planning - Draw First
+
+**ALWAYS sketch the UI before writing code.** Use ASCII diagrams to visualize:
+
+- Where UI elements appear in the backoffice
+- Which extension types are needed
+- How components connect
+
+### Wireframe Annotation Format
+
+```
+┌─────────────────────────────────────────────────────┐
+│ [Header]                          [headerApp]       │
+├──────────┬──────────────────────────────────────────┤
+│ [Section]│ [Dashboard/Workspace]                    │
+│  │       │  ┌────────────────────────────────────┐  │
+│  ├─[Menu]│  │                                    │  │
+│  │  │    │  │   Your content area                │  │
+│  │  └─[X]│  │                                    │  │
+│  │       │  │   [uui-button] [uui-input]         │  │
+│  └─[Tree]│  │   [uui-box]                        │  │
+│          │  └────────────────────────────────────┘  │
+└──────────┴──────────────────────────────────────────┘
+```
+
+Label each part with:
+- **Extension type** in `[brackets]` - e.g., `[section]`, `[workspace]`, `[headerApp]`
+- **UUI components** as `[uui-*]` - e.g., `[uui-button]`, `[uui-box]`
+
+## 2. Extension Type Selection
+
+Identify which extension types you need:
+
+| UI Location | Extension Type | Sub-skill |
+|-------------|----------------|-----------|
+| Left sidebar tab | `section` | `umbraco-sections` |
+| Section navigation | `menu` | `umbraco-menu` |
+| Main content area | `dashboard` or `workspace` | `umbraco-dashboard`, `umbraco-workspace` |
+| Hierarchical data | `tree` | `umbraco-tree` |
+| Top right corner | `headerApp` | `umbraco-header-apps` |
+| Popup dialogs | `modal` | `umbraco-modals` |
+
+See [EXTENSION-MAP.md](./EXTENSION-MAP.md) for the complete visual reference.
+
+## 3. UUI Component Selection
+
+Identify `uui-*` components needed for your UI:
+
+- **Layout**: `uui-box`, `uui-card`, `uui-table`
+- **Forms**: `uui-input`, `uui-button`, `uui-checkbox`, `uui-select`
+- **Feedback**: `uui-loader`, `uui-badge`, `uui-tag`
+- **Navigation**: `uui-tab-group`, `uui-pagination`
+
+**Reference**: Browse the Umbraco.UI source at `/Users/philw/Projects/Umbraco.UI/` for component implementations and available properties.
+
+## 4. Data Flow Mapping
+
+Document how data flows through your extension:
+
+```
+[Context Provider]
+       │
+       ▼
+[Your Element] ──consume──► UmbContextToken
+       │
+       ▼
+[Repository] ──fetch──► [API/Store]
+```
+
+Key questions to answer:
+- What context do you need to consume? (e.g., `UMB_WORKSPACE_CONTEXT`)
+- Do you need a custom repository or existing one?
+- What API endpoints will you call? (requires `umbraco-openapi-client`)
+
+## 5. Planning Checklist
+
+Before writing code, confirm:
+
+- [ ] Wireframe drawn with extension types labeled
+- [ ] UUI components identified
+- [ ] Data sources/APIs identified
+- [ ] Sub-skills to invoke identified
+- [ ] File structure planned (element, context, repository as needed)
+
+---
+
+> **TIP**: Time spent planning saves debugging time. A clear wireframe prevents building the wrong extension type.

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: umbraco-backoffice
 description: Blueprints for Umbraco backoffice customisation - complete working examples showing how extension types combine
-version: 1.0.0
+version: 1.1.0
 location: managed
 allowed-tools: Read, Write, Edit, WebFetch
 ---

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
@@ -23,87 +23,20 @@ For details on individual extension types, invoke the referenced sub-skills.
 
 ---
 
-## Backoffice Extension Map
+## Required Workflow
 
-This diagram shows where ALL extension types appear in the Umbraco backoffice UI:
+**CRITICAL**: Follow this workflow for ALL extension development:
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│ HEADER BAR                                                                       │
-│ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐           ┌───────────────────┐ │
-│ │ Content │ │  Media  │ │Settings │ │ Section │  ...      │    Header Apps    │ │
-│ │         │ │         │ │         │ │  ****   │           │ (umbraco-header-  │ │
-│ │         │ │         │ │         │ │         │           │     apps)         │ │
-│ └─────────┘ └─────────┘ └─────────┘ └─────────┘           └───────────────────┘ │
-│      ^                        ^                                    ^            │
-│      │                        │                                    │            │
-│  (umbraco-sections)      Your Section                    User menu, search,     │
-│                                                          notifications          │
-├─────────────────────────────────────────────────────────────────────────────────┤
-│ SIDEBAR                    │  MAIN CONTENT AREA                                 │
-│ ┌────────────────────────┐ │ ┌─────────────────────────────────────────────────┐│
-│ │ SectionSidebarApp      │ │ │ Dashboard (umbraco-dashboard)                   ││
-│ │ (part of sections)     │ │ │ Shows when nothing selected in tree             ││
-│ │                        │ │ │ ┌─────────────────────────────────────────────┐ ││
-│ │ ┌────────────────────┐ │ │ │ │ Your welcome content, stats, quick actions │ ││
-│ │ │ Menu               │ │ │ │ └─────────────────────────────────────────────┘ ││
-│ │ │ (umbraco-menu)     │ │ │ └─────────────────────────────────────────────────┘│
-│ │ │                    │ │ │                                                    │
-│ │ │ ┌────────────────┐ │ │ │ ┌─────────────────────────────────────────────────┐│
-│ │ │ │ MenuItem       │ │ │ │ │ Workspace (umbraco-workspace)                   ││
-│ │ │ │ (umbraco-menu- │ │ │ │ │ Shows when entity selected                      ││
-│ │ │ │     items)     │ │ │ │ │ ┌─────────────────────────────────────────────┐ ││
-│ │ │ │                │ │ │ │ │ │ WorkspaceView tabs (Content, Settings...)  │ ││
-│ │ │ │ kind: "tree"───┼─┼─┼─┼─┤ │ ┌─────────┐ ┌─────────┐ ┌─────────┐       │ ││
-│ │ │ └────────────────┘ │ │ │ │ │ │ View 1  │ │ View 2  │ │ View 3  │       │ ││
-│ │ │                    │ │ │ │ │ └─────────┘ └─────────┘ └─────────┘       │ ││
-│ │ │ ┌────────────────┐ │ │ │ │ └─────────────────────────────────────────────┘ ││
-│ │ │ │ Tree           │ │ │ │ │                                                 ││
-│ │ │ │ (umbraco-tree) │ │ │ │ │ WorkspaceActions (Save, Delete...)             ││
-│ │ │ │                │ │ │ │ │ (umbraco-entity-actions)                        ││
-│ │ │ │ ├─ Folder      │ │ │ │ └─────────────────────────────────────────────────┘│
-│ │ │ │ │  └─ Item ────┼─┼─┼─┼──> entityType links to Workspace                  │
-│ │ │ │ └─ Item        │ │ │ │                                                    │
-│ │ │ │   (umbraco-    │ │ │ │ ┌─────────────────────────────────────────────────┐│
-│ │ │ │    tree-item)  │ │ │ │ │ Collection (umbraco-collection)                 ││
-│ │ │ └────────────────┘ │ │ │ │ List/grid view of items                         ││
-│ │ └────────────────────┘ │ │ │ ┌─────────────────────────────────────────────┐ ││
-│ └────────────────────────┘ │ │ │ CollectionView (umbraco-collection-view)    │ ││
-│                            │ │ │ CollectionAction (umbraco-collection-action)│ ││
-│                            │ │ └─────────────────────────────────────────────┘ ││
-│                            │ └─────────────────────────────────────────────────┘│
-├────────────────────────────┴────────────────────────────────────────────────────┤
-│ MODALS & OVERLAYS (umbraco-modals)                                              │
-│ ┌─────────────────────────────────────────────────────────────────────────────┐ │
-│ │ Pickers, confirmations, custom dialogs - appear above main content          │ │
-│ └─────────────────────────────────────────────────────────────────────────────┘ │
-├─────────────────────────────────────────────────────────────────────────────────┤
-│ PROPERTY EDITORS (in Document/Media workspaces)                                 │
-│ ┌─────────────────────────────────────────────────────────────────────────────┐ │
-│ │ PropertyEditorUI (umbraco-property-editor-ui)  - The visual editor          │ │
-│ │ PropertyEditorSchema (umbraco-property-editor-schema) - Data validation     │ │
-│ │ PropertyAction (umbraco-property-action) - Buttons on property              │ │
-│ └─────────────────────────────────────────────────────────────────────────────┘ │
-├─────────────────────────────────────────────────────────────────────────────────┤
-│ RICH TEXT EDITOR (Tiptap)                                                       │
-│ ┌─────────────────────────────────────────────────────────────────────────────┐ │
-│ │ TiptapExtension (umbraco-tiptap-extension) - Core editor behavior           │ │
-│ │ TiptapToolbarExtension (umbraco-tiptap-toolbar-extension) - Toolbar buttons │ │
-│ │ TiptapStatusbarExtension (umbraco-tiptap-statusbar-extension) - Status bar  │ │
-│ └─────────────────────────────────────────────────────────────────────────────┘ │
-├─────────────────────────────────────────────────────────────────────────────────┤
-│ GLOBAL FEATURES                                                                 │
-│ ┌─────────────────────────────────────────────────────────────────────────────┐ │
-│ │ SearchProvider (umbraco-search-provider) - Global search results            │ │
-│ │ SearchResultItem (umbraco-search-result-item) - Custom result rendering     │ │
-│ │ HealthCheck (umbraco-health-check) - Settings > Health Check                │ │
-│ │ Theme (umbraco-theme) - Custom backoffice themes                            │ │
-│ │ Icons (umbraco-icons) - Custom icon sets                                    │ │
-│ │ AuthProvider (umbraco-auth-provider) - External login buttons               │ │
-│ │ MfaLoginProvider (umbraco-mfa-login-provider) - 2FA methods                 │ │
-│ └─────────────────────────────────────────────────────────────────────────────┘ │
-└─────────────────────────────────────────────────────────────────────────────────┘
+1. PLAN ──► Read PRE-BUILD-PLANNING.md, draw wireframes, identify extension types
+      ↓
+2. BUILD ──► Use examples and sub-skills to create extension
+      ↓
+3. VALIDATE ──► Read POST-BUILD-VALIDATION.md, run umbraco-extension-reviewer
 ```
+
+- **Never skip planning** - Wireframes prevent building the wrong extension type
+- **Never skip validation** - The reviewer catches issues before they reach users
 
 ---
 
@@ -127,112 +60,6 @@ Each example has a detailed README.md with full documentation. See the `examples
 
 ---
 
-## All Available Sub-Skills
-
-### UI Extension Skills
-Invoke these skills for detailed documentation on each extension type:
-
-| Extension Type | Sub-Skill | Where It Appears |
-|----------------|-----------|------------------|
-| Section | `umbraco-sections` | Top navigation bar |
-| Dashboard | `umbraco-dashboard` | Main content area |
-| Menu | `umbraco-menu` | Sidebar container |
-| MenuItem | `umbraco-menu-items` | Sidebar navigation items |
-| Tree | `umbraco-tree` | Hierarchical sidebar navigation |
-| TreeItem | `umbraco-tree-item` | Individual tree nodes |
-| Workspace | `umbraco-workspace` | Entity editing views |
-| Header App | `umbraco-header-apps` | Top-right header area |
-| Modal | `umbraco-modals` | Overlay dialogs |
-| Collection | `umbraco-collection` | List/grid views |
-| CollectionView | `umbraco-collection-view` | Custom collection layouts |
-| CollectionAction | `umbraco-collection-action` | Collection toolbar buttons |
-
-### Action Skills
-| Action Type | Sub-Skill | What It Does |
-|-------------|-----------|--------------|
-| Entity Action | `umbraco-entity-actions` | Context menu & workspace actions |
-| Entity Bulk Action | `umbraco-entity-bulk-actions` | Multi-select operations |
-| Entity Create Option | `umbraco-entity-create-option-action` | Create menu options |
-| Property Action | `umbraco-property-action` | Buttons on property editors |
-| Current User Action | `umbraco-current-user-action` | User profile menu items |
-
-### Property Editor Skills
-| Component | Sub-Skill | Purpose |
-|-----------|-----------|---------|
-| Property Editor UI | `umbraco-property-editor-ui` | Visual editor component |
-| Property Editor Schema | `umbraco-property-editor-schema` | Data validation |
-| Property Value Preset | `umbraco-property-value-preset` | Default value templates |
-| Block Editor Custom View | `umbraco-block-editor-custom-view` | Custom block rendering |
-
-### Rich Text Editor Skills
-| Component | Sub-Skill | Purpose |
-|-----------|-----------|---------|
-| Tiptap Extension | `umbraco-tiptap-extension` | Core editor behavior |
-| Tiptap Toolbar | `umbraco-tiptap-toolbar-extension` | Toolbar buttons |
-| Tiptap Statusbar | `umbraco-tiptap-statusbar-extension` | Status bar items |
-| Monaco Markdown Action | `umbraco-monaco-markdown-editor-action` | Markdown editor buttons |
-
-### Search & Global Features
-| Feature | Sub-Skill | Purpose |
-|---------|-----------|---------|
-| Search Provider | `umbraco-search-provider` | Global search integration |
-| Search Result Item | `umbraco-search-result-item` | Custom result rendering |
-| Health Check | `umbraco-health-check` | System health checks |
-| Theme | `umbraco-theme` | Custom backoffice themes |
-| Icons | `umbraco-icons` | Custom icon sets |
-
-### Authentication Skills
-| Component | Sub-Skill | Purpose |
-|-----------|-----------|---------|
-| Auth Provider | `umbraco-auth-provider` | External login (OAuth) |
-| MFA Login Provider | `umbraco-mfa-login-provider` | Two-factor authentication |
-
-### User & Package Skills
-| Component | Sub-Skill | Purpose |
-|-----------|-----------|---------|
-| User Profile App | `umbraco-user-profile-app` | User profile tabs |
-| Granular Permissions | `umbraco-granular-user-permissions` | Fine-grained access control |
-| Package View | `umbraco-package-view` | Package configuration UI |
-| File Upload Preview | `umbraco-file-upload-preview` | Custom upload previews |
-| Preview App Provider | `umbraco-preview-app-provider` | Content preview apps |
-
-### Advanced Configuration
-| Component | Sub-Skill | Purpose |
-|-----------|-----------|---------|
-| Dynamic Root | `umbraco-dynamic-root` | Content picker root configuration |
-| Kinds | `umbraco-kinds` | Reusable manifest templates |
-| UFM Component | `umbraco-ufm-component` | Umbraco Flavored Markdown |
-| Global Context | `umbraco-global-context` | App-wide shared state |
-
-### Foundation Concepts
-Essential patterns used across all extensions:
-
-| Concept | Sub-Skill | When Needed |
-|---------|-----------|-------------|
-| **OpenAPI Client** | `umbraco-openapi-client` | **REQUIRED for all custom API calls** |
-| Context API | `umbraco-context-api` | Accessing services, sharing data |
-| Umbraco Element | `umbraco-umbraco-element` | Base class for components |
-| Conditions | `umbraco-conditions` | Controlling where things appear |
-| State Management | `umbraco-state-management` | Reactive UI with @state |
-| Repository Pattern | `umbraco-repository-pattern` | Data access layer |
-| Extension Registry | `umbraco-extension-registry` | Dynamic registration |
-| Routing | `umbraco-routing` | URL structure, navigation |
-| Localization | `umbraco-localization` | Multi-language support |
-| Notifications | `umbraco-notifications` | Toast messages, events |
-| Controllers | `umbraco-controllers` | C# API endpoints |
-
-> **CRITICAL**: When calling custom C# API endpoints from the backoffice, **NEVER use raw `fetch()`**. This will result in 401 Unauthorized errors. Always use a generated OpenAPI client configured with Umbraco's auth context. See the `umbraco-openapi-client` skill.
-
-### Build & Structure
-| Component | Sub-Skill | Purpose |
-|-----------|-----------|---------|
-| Bundle | `umbraco-bundle` | Manifest aggregation |
-| Entry Point | `umbraco-entry-point` | Runtime initialization |
-| Extension Template | `umbraco-extension-template` | Project scaffolding |
-| **Add Extension Reference** | `umbraco-add-extension-reference` | **Register extension in Umbraco instance** |
-
----
-
 ## Using the Examples
 
 1. **Browse** the `examples/` folder and read the README.md for each example
@@ -245,41 +72,13 @@ Essential patterns used across all extensions:
 
 ---
 
-## Post-Build Review & Validation
+## Reference Documentation
 
-After creating or modifying an extension, trigger the following agents to ensure quality:
+Detailed reference material is available in separate files for on-demand loading:
 
-### Agent Triggering Flow
-
-```
-Extension Built/Loaded
-        ↓
-┌───────────────────────────────────────┐
-│  AGENT: skill-quality-reviewer        │
-│  - Review code patterns               │
-│  - Fix outdated imports/types         │
-│  - Apply documentation-based fixes    │
-└───────────────────────────────────────┘
-        ↓
-Load Skills for Validation
-        ↓
-Run validate-skills
-```
-
-### Agent Summary
-
-| Agent | Purpose | Trigger Point |
-|-------|---------|---------------|
-| `umbraco-extension-reviewer` | QA review for best practices | After any umbraco-* skill generates code |
-| `skill-quality-reviewer` | Fix code patterns, imports, types | After extension build/load, before validation |
-
-### Workflow Integration
-
-When creating extensions, the recommended flow is:
-
-1. **Create extension** using appropriate skill (e.g., `umbraco-dashboard`, `umbraco-workspace`)
-2. **Spawn `umbraco-extension-reviewer`** to review generated code against best practices
-3. **Spawn `skill-quality-reviewer`** if code issues need documentation-based fixes
-4. **Run `validate-skills`** to check links, code, and tests
-
-> **TIP**: The `umbraco-extension-reviewer` agent should run automatically after any umbraco-* skill generates code. This ensures extensions follow Umbraco's architecture and best practices.
+| Reference | When to Read |
+|-----------|--------------|
+| [PRE-BUILD-PLANNING.md](./PRE-BUILD-PLANNING.md) | Before building any extension - visual planning, wireframes, UUI components |
+| [EXTENSION-MAP.md](./EXTENSION-MAP.md) | "Where does extension type X appear in the UI?" - ASCII diagram showing all extension locations |
+| [SUB-SKILLS-REFERENCE.md](./SUB-SKILLS-REFERENCE.md) | "What skill do I need for X?" - Complete index of all sub-skills by category |
+| [POST-BUILD-VALIDATION.md](./POST-BUILD-VALIDATION.md) | After building - complete validation workflow, browser testing, debugging |

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SUB-SKILLS-REFERENCE.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SUB-SKILLS-REFERENCE.md
@@ -1,0 +1,115 @@
+# Sub-Skills Reference
+
+Complete index of all available sub-skills for Umbraco backoffice development.
+
+## UI Extension Skills
+
+Invoke these skills for detailed documentation on each extension type:
+
+| Extension Type | Sub-Skill | Where It Appears |
+|----------------|-----------|------------------|
+| Section | `umbraco-sections` | Top navigation bar |
+| Dashboard | `umbraco-dashboard` | Main content area |
+| Menu | `umbraco-menu` | Sidebar container |
+| MenuItem | `umbraco-menu-items` | Sidebar navigation items |
+| Tree | `umbraco-tree` | Hierarchical sidebar navigation |
+| TreeItem | `umbraco-tree-item` | Individual tree nodes |
+| Workspace | `umbraco-workspace` | Entity editing views |
+| Header App | `umbraco-header-apps` | Top-right header area |
+| Modal | `umbraco-modals` | Overlay dialogs |
+| Collection | `umbraco-collection` | List/grid views |
+| CollectionView | `umbraco-collection-view` | Custom collection layouts |
+| CollectionAction | `umbraco-collection-action` | Collection toolbar buttons |
+
+## Action Skills
+
+| Action Type | Sub-Skill | What It Does |
+|-------------|-----------|--------------|
+| Entity Action | `umbraco-entity-actions` | Context menu & workspace actions |
+| Entity Bulk Action | `umbraco-entity-bulk-actions` | Multi-select operations |
+| Entity Create Option | `umbraco-entity-create-option-action` | Create menu options |
+| Property Action | `umbraco-property-action` | Buttons on property editors |
+| Current User Action | `umbraco-current-user-action` | User profile menu items |
+
+## Property Editor Skills
+
+| Component | Sub-Skill | Purpose |
+|-----------|-----------|---------|
+| Property Editor UI | `umbraco-property-editor-ui` | Visual editor component |
+| Property Editor Schema | `umbraco-property-editor-schema` | Data validation |
+| Property Value Preset | `umbraco-property-value-preset` | Default value templates |
+| Block Editor Custom View | `umbraco-block-editor-custom-view` | Custom block rendering |
+
+## Rich Text Editor Skills
+
+| Component | Sub-Skill | Purpose |
+|-----------|-----------|---------|
+| Tiptap Extension | `umbraco-tiptap-extension` | Core editor behavior |
+| Tiptap Toolbar | `umbraco-tiptap-toolbar-extension` | Toolbar buttons |
+| Tiptap Statusbar | `umbraco-tiptap-statusbar-extension` | Status bar items |
+| Monaco Markdown Action | `umbraco-monaco-markdown-editor-action` | Markdown editor buttons |
+
+## Search & Global Features
+
+| Feature | Sub-Skill | Purpose |
+|---------|-----------|---------|
+| Search Provider | `umbraco-search-provider` | Global search integration |
+| Search Result Item | `umbraco-search-result-item` | Custom result rendering |
+| Health Check | `umbraco-health-check` | System health checks |
+| Theme | `umbraco-theme` | Custom backoffice themes |
+| Icons | `umbraco-icons` | Custom icon sets |
+
+## Authentication Skills
+
+| Component | Sub-Skill | Purpose |
+|-----------|-----------|---------|
+| Auth Provider | `umbraco-auth-provider` | External login (OAuth) |
+| MFA Login Provider | `umbraco-mfa-login-provider` | Two-factor authentication |
+
+## User & Package Skills
+
+| Component | Sub-Skill | Purpose |
+|-----------|-----------|---------|
+| User Profile App | `umbraco-user-profile-app` | User profile tabs |
+| Granular Permissions | `umbraco-granular-user-permissions` | Fine-grained access control |
+| Package View | `umbraco-package-view` | Package configuration UI |
+| File Upload Preview | `umbraco-file-upload-preview` | Custom upload previews |
+| Preview App Provider | `umbraco-preview-app-provider` | Content preview apps |
+
+## Advanced Configuration
+
+| Component | Sub-Skill | Purpose |
+|-----------|-----------|---------|
+| Dynamic Root | `umbraco-dynamic-root` | Content picker root configuration |
+| Kinds | `umbraco-kinds` | Reusable manifest templates |
+| UFM Component | `umbraco-ufm-component` | Umbraco Flavored Markdown |
+| Global Context | `umbraco-global-context` | App-wide shared state |
+
+## Foundation Concepts
+
+Essential patterns used across all extensions:
+
+| Concept | Sub-Skill | When Needed |
+|---------|-----------|-------------|
+| **OpenAPI Client** | `umbraco-openapi-client` | **REQUIRED for all custom API calls** |
+| Context API | `umbraco-context-api` | Accessing services, sharing data |
+| Umbraco Element | `umbraco-umbraco-element` | Base class for components |
+| Conditions | `umbraco-conditions` | Controlling where things appear |
+| State Management | `umbraco-state-management` | Reactive UI with @state |
+| Repository Pattern | `umbraco-repository-pattern` | Data access layer |
+| Extension Registry | `umbraco-extension-registry` | Dynamic registration |
+| Routing | `umbraco-routing` | URL structure, navigation |
+| Localization | `umbraco-localization` | Multi-language support |
+| Notifications | `umbraco-notifications` | Toast messages, events |
+| Controllers | `umbraco-controllers` | C# API endpoints |
+
+> **CRITICAL**: When calling custom C# API endpoints from the backoffice, **NEVER use raw `fetch()`**. This will result in 401 Unauthorized errors. Always use a generated OpenAPI client configured with Umbraco's auth context. See the `umbraco-openapi-client` skill.
+
+## Build & Structure
+
+| Component | Sub-Skill | Purpose |
+|-----------|-----------|---------|
+| Bundle | `umbraco-bundle` | Manifest aggregation |
+| Entry Point | `umbraco-entry-point` | Runtime initialization |
+| Extension Template | `umbraco-extension-template` | Project scaffolding |
+| **Add Extension Reference** | `umbraco-add-extension-reference` | **Register extension in Umbraco instance** |


### PR DESCRIPTION
## Summary

- Add `PRE-BUILD-PLANNING.md` with visual planning requirements, wireframe annotation format, UUI component selection, and data flow mapping guidance
- Expand `POST-BUILD-VALIDATION.md` from 38 to 154 lines with complete build-test workflow, browser testing checklist, auto-fix policy, and debugging steps
- Refactor `SKILL.md` to use on-demand reference files (EXTENSION-MAP.md, SUB-SKILLS-REFERENCE.md) and add "Required Workflow" section emphasizing mandatory planning and validation

## Motivation

These workflow practices were previously in a project-specific CLAUDE.md file. Embedding them in the skills system makes them:
- **Automatically available** without requiring a project-specific CLAUDE.md
- **Consistently applied** across all projects using these skills
- **Loaded on-demand** only when relevant (reference files)

## Test plan

- [ ] Read PRE-BUILD-PLANNING.md - verify planning workflow is clear
- [ ] Read POST-BUILD-VALIDATION.md - verify testing workflow is complete
- [ ] Read SKILL.md - verify reference links work
- [ ] Invoke `umbraco-backoffice` skill - verify Required Workflow section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)