### PR TITLE
Require loading umbraco-backoffice skill as first plan step

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Umbraco backoffice customization skills for Claude Code",
-    "version": "17.0.0-beta.5",
+    "version": "17.0.0-beta.6",
     "homepage": "https://github.com/hifi-phil/UmbracoCMS_Skills"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umbraco-cms-backoffice-skills",
       "source": "./plugins/umbraco-backoffice-skills",
       "description": "Umbraco backoffice skills covering Foundation, Extension Types, Property Editors, Rich Text, Backend, and Setup",
-      "version": "17.0.0-beta.5",
+      "version": "17.0.0-beta.6",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",

--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "17.0.0-beta.5",
+  "version": "17.0.0-beta.6",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",

--- a/plugins/umbraco-backoffice-skills/agents/umbraco-extension-reviewer.md
+++ b/plugins/umbraco-backoffice-skills/agents/umbraco-extension-reviewer.md
@@ -1,171 +1,60 @@
 ---
 name: umbraco-extension-reviewer
-description: QA agent that AUTOMATICALLY runs after umbraco-* skills complete to validate output follows best practices and embraces Umbraco's architecture. Use this agent proactively when you detect an umbraco skill has just generated code.
+description: QA agent that validates Umbraco backoffice extensions follow best practices. Spawn after code generation to review and auto-fix issues.
 
 <example>
-Context: Assistant just used umbraco-dashboard skill and generated code.
 user: "Create a dashboard for content analytics"
 assistant: [Uses umbraco-dashboard skill, generates code]
-assistant: "Dashboard created. Now I'll run the umbraco-extension-reviewer to validate it follows best practices."
+assistant: "Now I'll validate the code follows best practices."
 <Task tool call to umbraco-extension-reviewer agent>
 </example>
-
-<example>
-Context: User explicitly requests review.
-user: "Review this extension code for best practices"
-assistant: "I'll use the umbraco-extension-reviewer agent to validate the code."
-<Task tool call to umbraco-extension-reviewer agent>
-</example>
-tools: Read, Edit, Write, Glob, Grep, WebFetch
+tools: Read, Edit, Write, Glob, Grep
 model: sonnet
 ---
 
-You are the quality assurance agent for Umbraco backoffice extensions. You run AFTER skill-generated code to validate quality, ensure best practices, and verify the code embraces Umbraco's architecture.
+You are the QA agent for Umbraco backoffice extensions. Review generated code and fix issues.
 
-## Core Philosophy: Embrace the System
+## Process
 
-**Extensions should work WITH Umbraco, not against it.**
+### 1. Load Review Checks
 
-The Umbraco backoffice provides a rich set of extension points, patterns, and conventions. Good extensions:
-- Use available extension types instead of reinventing them
-- Follow established architectural patterns
-- Leverage the extension registry system
-- Use proper contexts, controllers, and repositories
-- Follow naming conventions from the Umbraco source
+**Invoke the skill:**
+```
+/umbraco-review-checks
+```
 
-## Auto-Apply Policy
+### 2. Apply Checks
 
-**FIX issues automatically when safe:**
+Apply the checks from the skill. Auto-fix safe issues (marked with "Auto-Fix: Yes"). Report others with recommended fixes.
 
-| Issue | Auto-Fix Action |
-|-------|----------------|
-| `LitElement` base class | Replace with `UmbLitElement`, add import |
-| Simple `alert()` calls | Replace with notification context call |
-| Missing `@state()` decorator | Add decorator to private reactive properties |
-| Direct `lit` import | Replace with `@umbraco-cms/backoffice/external/lit` |
-
-**Report without fixing if:**
-- Changes would significantly alter functionality
-- Multiple valid approaches exist (ask user)
-- Fix requires architectural refactoring
-
-## Review Process
-
-### Step 1: Detect Extension Type
-
-Analyze the code to determine what type of extension is being reviewed:
-
-| Type | Detection |
-|------|-----------|
-| Dashboard | `type: 'dashboard'` in manifest |
-| Property Editor | `type: 'propertyEditorUi'` or `type: 'propertyEditorSchema'` |
-| Workspace | `type: 'workspace'` or workspace-related elements |
-| Section | `type: 'section'` in manifest |
-| Tree | `type: 'tree'` in manifest |
-| Collection | `type: 'collection'` in manifest |
-| Entity Action | `type: 'entityAction'` in manifest |
-| Header App | `type: 'headerApp'` in manifest |
-| Modal | Modal-related code |
-
-### Step 2: Load Review Checks
-
-Read the `umbraco-review-checks` skill from `../skills/umbraco-review-checks/SKILL.md` for all check definitions.
-
-Apply checks based on extension type:
-
-| Extension Type | Check Categories |
-|---------------|------------------|
-| Dashboard | Code Quality (all), Architecture (all), UI Patterns (all) |
-| Property Editor | Code Quality (all), UI Patterns (all) |
-| Workspace | Code Quality (all), Architecture (all), UI Patterns (all) |
-| Section | Code Quality (all), Architecture (all), UI Patterns (all) |
-| Tree | Code Quality (all), Architecture (AR-1 to AR-5) |
-| Collection | Code Quality (all), Architecture (all), UI Patterns (all) |
-| Entity Action | Code Quality (all) |
-| Header App | Code Quality (all), UI Patterns (all) |
-| Modal | Code Quality (all), UI Patterns (all) |
-| Context/Repository | Code Quality (all), Architecture (all) |
-
-### Step 3: Apply Checks
-
-For each applicable check from `umbraco-review-checks`:
-1. Apply the check detection criteria to the code
-2. Note findings with check ID (e.g., CQ-1, AR-2, UI-3), severity, and line numbers
-3. Auto-fix where safe per Auto-Apply Policy
-
-### Step 4: Generate Report
-
-## Reference Skills
-
-When flagging issues, reference these skills for detailed fix guidance:
-
-| Pattern Area | Skill Reference |
-|--------------|-----------------|
-| Repository pattern | `umbraco-repository-pattern` |
-| Workspace context | `umbraco-workspace` |
-| Notifications | `umbraco-notifications` |
-| Context API | `umbraco-context-api` |
-| State management | `umbraco-state-management` |
-| Localization | `umbraco-localization` |
-| Conditions | `umbraco-conditions` |
-
-## Output Format
+### 3. Output Report
 
 ```
 ## Review Summary
 
-**Extension Type:** [detected type]
+**Extension Type:** [type]
 **Files Reviewed:** [count]
-**Issues Found:** [critical] critical, [high] high, [medium] medium, [low] low
+**Issues:** [counts by severity]
 **Auto-Fixes Applied:** [count]
 
 ## Auto-Fixes Applied
 
-### [Fix Title]
-**File:** `path/to/file.ts`
-**Change:** [brief description]
+[List each fix with file, change description, and diff]
 
-```diff
-- [old code]
-+ [new code]
+## Issues (Manual Review Needed)
+
+[List remaining issues with file, line, problem, and recommended fix]
 ```
 
-## Issues (Require Manual Review)
+## Post-Review Actions (MANDATORY)
 
-### [Critical/High] [Issue Title]
-**File:** `path/to/file.ts`
-**Line:** [line number]
-**Check:** [check name]
+After fixes are applied:
 
-**Problem:** [Description]
+1. **Build the extension:**
+   ```bash
+   npm run build
+   ```
 
-**Current Code:**
-```typescript
-[problematic code]
-```
+2. **Restart Umbraco** to pick up changes
 
-**Recommended Fix:**
-```typescript
-[corrected code]
-```
-
-**Reference:** `[skill-name]` skill
-
-## Pattern Alignment
-
-- [What aligns well with Umbraco patterns]
-- [What could be improved]
-```
-
-## Common Anti-Patterns to Fix
-
-1. **Direct API calls in UI elements** - Use repository pattern via context
-2. **Custom routing instead of extension types** - Use dashboard, workspace, etc.
-3. **Direct DOM manipulation** - Use Lit reactive properties
-4. **Global state/singletons** - Use Context API
-5. **Hardcoded strings** - Add localization
-6. **Browser `alert()` calls** - Use notification context
-7. **Native HTML form elements** - Use UUI components
-8. **Save buttons in content area** - Use `<umb-workspace-editor>`
-
-Remember: The goal is extensions that feel native to Umbraco, not custom applications bolted on.
+**Without these steps, fixes will NOT be visible.**

--- a/plugins/umbraco-backoffice-skills/agents/umbraco-extension-reviewer.md
+++ b/plugins/umbraco-backoffice-skills/agents/umbraco-extension-reviewer.md
@@ -1,14 +1,20 @@
 ---
 name: umbraco-extension-reviewer
-description: QA agent that validates Umbraco backoffice extensions follow best practices. Spawn after code generation to review and auto-fix issues.
+description: QA agent that AUTOMATICALLY runs after umbraco-* skills complete to validate output follows best practices and embraces Umbraco's architecture. Use this agent proactively when you detect an umbraco skill has just generated code.
 
 <example>
 user: "Create a dashboard for content analytics"
 assistant: [Uses umbraco-dashboard skill, generates code]
-assistant: "Now I'll validate the code follows best practices."
+assistant: "Dashboard created. Now I'll run the umbraco-extension-reviewer to validate it follows best practices."
 <Task tool call to umbraco-extension-reviewer agent>
 </example>
-tools: Read, Edit, Write, Glob, Grep
+<example>
+Context: User explicitly requests review.
+user: "Review this extension code for best practices"
+assistant: "I'll use the umbraco-extension-reviewer agent to validate the code."
+<Task tool call to umbraco-extension-reviewer agent>
+</example>
+tools: Read, Edit, Write, Glob, Grep, WebFetch
 model: sonnet
 ---
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: umbraco-backoffice
-description: Blueprints for Umbraco backoffice customisation - complete working examples showing how extension types combine
+description: Umbraco backoffice extension customisation - complete working examples showing how extension types combine
 version: 1.3.0
 location: managed
 allowed-tools: Read, Write, Edit, WebFetch
 ---
 
-# Umbraco Backoffice Blueprints
+# Umbraco Backoffice Extensions Overview
 
 ## What This Skill Does
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: umbraco-backoffice
 description: Blueprints for Umbraco backoffice customisation - complete working examples showing how extension types combine
-version: 1.2.0
+version: 1.3.0
 location: managed
 allowed-tools: Read, Write, Edit, WebFetch
 ---

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -119,8 +119,9 @@ When the user describes what they want:
    - Identify UUI components
    - Map data flow (contexts, APIs)
 3. Identify which sub-skills to invoke
-4. **The first step of the implementation plan MUST be:** Load `/umbraco-backoffice` skill
-   - This ensures blueprints and examples are available during the build phase
+4. **Include a "Pre-Build Validation" section in the plan:**
+    Load `/umbraco-backoffice` skill
+   - This ensures best practice and examples are available during the build phase
 5. **Include a "Post-Build Validation" section in the plan:**
    ```markdown
    ## Post-Build Validation (REQUIRED)

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -146,7 +146,8 @@ After ALL code generation is complete:
 1. **Run `npm run build`** - must compile without errors
 2. **Spawn `umbraco-extension-reviewer` agent** - MANDATORY code review
 3. Fix any High/Medium severity issues automatically
-4. Guide user through browser testing per POST-BUILD-VALIDATION.md
+4. **ALWAYS** restart Umbraco instance before testing
+5. Guide user through browser testing per POST-BUILD-VALIDATION.md
 
 ## Goal
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -119,7 +119,9 @@ When the user describes what they want:
    - Identify UUI components
    - Map data flow (contexts, APIs)
 3. Identify which sub-skills to invoke
-4. **Include a "Post-Build Validation" section in the plan:**
+4. **The first step of the implementation plan MUST be:** Load `/umbraco-backoffice` skill
+   - This ensures blueprints and examples are available during the build phase
+5. **Include a "Post-Build Validation" section in the plan:**
    ```markdown
    ## Post-Build Validation (REQUIRED)
 
@@ -129,7 +131,7 @@ When the user describes what they want:
    - [ ] Fix all High/Medium severity issues
    - [ ] Browser test: extension loads, UI renders, interactions work
    ```
-5. Exit plan mode only when wireframe AND validation steps are in the plan
+6. Exit plan mode only when wireframe AND validation steps are in the plan
 
 **⚠️ Do NOT generate code until planning is complete and approved by the user.**
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -129,25 +129,13 @@ When the user describes what they want:
    - [ ] Run `npm run build` - must compile without errors
    - [ ] Spawn `umbraco-extension-reviewer` agent for code review
    - [ ] Fix all High/Medium severity issues
+   - [ ] ALWAYS restart Umbraco instance before testing
    - [ ] Browser test: extension loads, UI renders, interactions work
    ```
 6. Exit plan mode only when wireframe AND validation steps are in the plan
 
 **⚠️ Do NOT generate code until planning is complete and approved by the user.**
 
-### 6. Build the Extension
-
-Use the identified sub-skills to generate code.
-
-### 7. MANDATORY: Post-Build Validation
-
-After ALL code generation is complete:
-
-1. **Run `npm run build`** - must compile without errors
-2. **Spawn `umbraco-extension-reviewer` agent** - MANDATORY code review
-3. Fix any High/Medium severity issues automatically
-4. **ALWAYS** restart Umbraco instance before testing
-5. Guide user through browser testing per POST-BUILD-VALIDATION.md
 
 ## Goal
 


### PR DESCRIPTION
## Summary

Updates `umbraco-quickstart` workflow to require that the first step of the implementation plan loads the `/umbraco-backoffice` skill.

This ensures blueprints and examples are available in context during the build phase.

## Change

Added step 4 to the planning instructions:
> **The first step of the implementation plan MUST be:** Load `/umbraco-backoffice` skill
> - This ensures blueprints and examples are available during the build phase

## Test plan

- [ ] Invoke `/umbraco-quickstart` and describe an extension
- [ ] Verify the generated plan's first implementation step is to load `/umbraco-backoffice`

🤖 Generated with [Claude Code](https://claude.com/claude-code)