### PR TITLE
Bump versions to 17.0.0-beta.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Umbraco backoffice customization skills for Claude Code",
-    "version": "17.0.0-beta.6",
+    "version": "17.0.0-beta.7",
     "homepage": "https://github.com/hifi-phil/UmbracoCMS_Skills"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umbraco-cms-backoffice-skills",
       "source": "./plugins/umbraco-backoffice-skills",
       "description": "Umbraco backoffice skills covering Foundation, Extension Types, Property Editors, Rich Text, Backend, and Setup",
-      "version": "17.0.0-beta.6",
+      "version": "17.0.0-beta.7",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",

--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "17.0.0-beta.6",
+  "version": "17.0.0-beta.7",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-property-editor-ui/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-property-editor-ui/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: umbraco-property-editor-ui
 description: Implement property editor UIs in Umbraco backoffice using official docs
-version: 1.0.0
+version: 1.1.0
 location: managed
 allowed-tools: Read, Write, Edit, WebFetch
 ---

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-review-checks/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: umbraco-review-checks
 description: Review checks reference for validating Umbraco backoffice extensions
-version: 1.0.0
+version: 1.1.0
 location: managed
 allowed-tools: Read
 ---


### PR DESCRIPTION
## Summary

- Bumps marketplace and plugin versions to 17.0.0-beta.7
- Bumps modified skills to 1.1.0:
  - `umbraco-property-editor-ui` (schema warning added in #22)
  - `umbraco-review-checks` (CQ-9 check added in #22)

🤖 Generated with [Claude Code](https://claude.ai/code)