### PR TITLE
Add troubleshooting docs for property editor UI skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Umbraco backoffice customization skills for Claude Code",
-    "version": "17.0.0-beta.8",
+    "version": "17.0.0-beta.9",
     "homepage": "https://github.com/hifi-phil/UmbracoCMS_Skills"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umbraco-cms-backoffice-skills",
       "source": "./plugins/umbraco-backoffice-skills",
       "description": "Umbraco backoffice skills covering Foundation, Extension Types, Property Editors, Rich Text, Backend, and Setup",
-      "version": "17.0.0-beta.8",
+      "version": "17.0.0-beta.9",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",

--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "17.0.0-beta.8",
+  "version": "17.0.0-beta.9",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-property-editor-ui/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-property-editor-ui/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: umbraco-property-editor-ui
 description: Implement property editor UIs in Umbraco backoffice using official docs
-version: 1.1.0
+version: 1.2.0
 location: managed
 allowed-tools: Read, Write, Edit, WebFetch
 ---
@@ -208,29 +208,11 @@ These built-in schemas are always available:
 
 ## Troubleshooting
 
-### 404 Error When Creating Data Type
+See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for common issues including:
+- 404 errors when creating Data Types
+- Values not persisting with `Umbraco.Plain.Json`
 
-**Symptom:** Data Type fails to save, browser DevTools shows 404 when fetching schema.
-
-**Cause:** The `propertyEditorSchemaAlias` references a schema that doesn't exist on the server.
-
-**Solution:**
-1. **Use a built-in schema** (recommended) - Change to `Umbraco.Plain.String`, `Umbraco.Integer`, etc.
-2. **Create a C# DataEditor** - If you need custom behavior, implement the schema server-side:
-
-```csharp
-[DataEditor(
-    alias: "MyPackage.CustomSchema",
-    ValueType = ValueTypes.Integer)]
-public class MyCustomPropertyEditor : DataEditor
-{
-    public MyCustomPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
-        : base(dataValueEditorFactory)
-    { }
-}
-```
-
-See skill: `umbraco-property-editor-schema` for full details on creating custom schemas.
+See [UUI-GOTCHAS.md](./UUI-GOTCHAS.md) for UUI component issues (combobox, input, etc.).
 
 ---
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-property-editor-ui/TROUBLESHOOTING.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-property-editor-ui/TROUBLESHOOTING.md
@@ -1,0 +1,113 @@
+# Property Editor UI Troubleshooting
+
+Common issues and solutions when building property editor UIs.
+
+---
+
+## 404 Error When Creating Data Type
+
+**Symptom:** Data Type fails to save, browser DevTools shows 404 when fetching schema.
+
+**Cause:** The `propertyEditorSchemaAlias` references a schema that doesn't exist on the server.
+
+**Solution:**
+1. **Use a built-in schema** (recommended) - Change to `Umbraco.Plain.String`, `Umbraco.Integer`, etc.
+2. **Create a C# DataEditor** - If you need custom behavior, implement the schema server-side:
+
+```csharp
+[DataEditor(
+    alias: "MyPackage.CustomSchema",
+    ValueType = ValueTypes.Integer)]
+public class MyCustomPropertyEditor : DataEditor
+{
+    public MyCustomPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
+        : base(dataValueEditorFactory)
+    { }
+}
+```
+
+See skill: `umbraco-property-editor-schema` for full details on creating custom schemas.
+
+---
+
+## Value Not Persisting with Umbraco.Plain.Json
+
+**Symptom:**
+- User selects/enters a value in the property editor
+- Value appears correct in console logs
+- After save or page reload, the field is empty
+- No errors in the console
+
+**Cause:** The `Umbraco.Plain.Json` schema stores **JavaScript objects directly**, not JSON strings.
+
+Common mistake - treating the value as a JSON string:
+
+```typescript
+// WRONG: Trying to work with JSON strings
+@property({ type: String })
+public value = "";
+
+#parseValue(): MyObject | null {
+  return this.value ? JSON.parse(this.value) : null;
+}
+
+#onChange(event: Event) {
+  const obj = event.target.value;
+  this.value = JSON.stringify(obj);  // Umbraco expects an object, not a string!
+  this.dispatchEvent(new UmbChangeEvent());
+}
+```
+
+When you do this:
+- Umbraco passes an object to your component
+- You try to `JSON.parse()` an object (fails silently or returns wrong type)
+- You `JSON.stringify()` and save a string
+- Umbraco may store it, but the round-trip breaks
+
+**Solution:** Work with objects directly when using `Umbraco.Plain.Json`:
+
+```typescript
+// CORRECT: Work with objects directly
+@property({ type: Object })
+public value: MyObject | null = null;
+
+#onChange(event: CustomEvent & { target: MyInputElement }) {
+  this.value = event.target.value;  // Pass object directly
+  this.dispatchEvent(new UmbChangeEvent());
+}
+
+override render() {
+  return html`
+    <my-input
+      .value=${this.value}
+      @change=${this.#onChange}>
+    </my-input>
+  `;
+}
+```
+
+### Schema Value Type Reference
+
+| Schema Alias | Value Type | `@property()` Type |
+|--------------|------------|-------------------|
+| `Umbraco.Plain.String` | `string` | `{ type: String }` |
+| `Umbraco.Plain.Integer` | `number` | `{ type: Number }` |
+| `Umbraco.Plain.Json` | `object` | `{ type: Object }` |
+| `Umbraco.TextBox` | `string` | `{ type: String }` |
+
+### Debugging Tip
+
+Add console logs to your value setter to see what Umbraco is actually passing:
+
+```typescript
+set value(val: unknown) {
+  console.log('[my-editor] value setter:', typeof val, val);
+  this._value = val as MyObject;
+}
+```
+
+---
+
+## UUI Component Issues
+
+See [UUI-GOTCHAS.md](./UUI-GOTCHAS.md) for issues specific to Umbraco UI Library components (combobox, input, etc.).

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-property-editor-ui/UUI-GOTCHAS.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-property-editor-ui/UUI-GOTCHAS.md
@@ -1,0 +1,62 @@
+# UUI Component Gotchas
+
+Common issues when working with Umbraco UI Library (UUI) components in property editors.
+
+---
+
+## Selection Not Working with uui-combobox
+
+**Symptom:**
+- User searches for items in a combobox dropdown
+- User clicks a search result to select it
+- The dropdown closes but the selected item doesn't display
+- No errors in the console
+
+**Cause:** The `uui-combobox` component fires events in this order when a selection is made:
+
+1. `@search` event fires when the dropdown closes (with empty search term)
+2. `@change` event fires to handle the selection
+
+If your `@search` handler clears the search results array when the search term is empty, the results are cleared *before* the `@change` event can look up the selected item.
+
+```typescript
+// PROBLEMATIC: Clearing results in search handler
+#onSearch(event: UUIComboboxEvent) {
+  const searchTerm = combobox.search?.trim() ?? "";
+  if (!searchTerm) {
+    this._searchResults = [];  // This clears results BEFORE @change fires!
+    return;
+  }
+  // ...perform search
+}
+```
+
+**Solution:** Maintain a separate cache of fetched items that persists independently of displayed search results:
+
+```typescript
+// Cache persists independently of displayed results
+#itemCache = new Map<string, ItemDetails>();
+
+async #performSearch(query: string): Promise<void> {
+  // ... fetch results ...
+  this._searchResults = results;
+
+  // Cache all fetched items for later lookup
+  for (const item of results) {
+    this.#itemCache.set(item.id.toString(), item);
+  }
+}
+
+#onSelect(event: UUIComboboxEvent) {
+  const selectedId = combobox.value as string;
+
+  // Look up from cache, NOT from _searchResults
+  const selectedItem = this.#itemCache.get(selectedId);
+
+  if (selectedItem) {
+    this.value = selectedItem;
+    this._searchResults = [];  // Safe to clear now
+    this.dispatchEvent(new UmbChangeEvent());
+  }
+}
+```


### PR DESCRIPTION
## Summary

- Extract troubleshooting content from SKILL.md into separate referenced files
- Add documentation for common property editor issues discovered during real-world implementation

## Changes

- **TROUBLESHOOTING.md** (new) - Umbraco-specific issues:
  - 404 errors when creating Data Types (existing, moved)
  - Value not persisting with `Umbraco.Plain.Json` schema (new)
  
- **UUI-GOTCHAS.md** (new) - UUI component issues:
  - Selection race condition with `uui-combobox`

- **SKILL.md** - Updated to reference the new files, bumped to v1.2.0

- **Versions** - Bumped to 17.0.0-beta.9

## Why

These issues were discovered during a real property editor implementation. They cause silent failures (no console errors) which makes them particularly hard to debug. Adding them to the skills helps AI assistants avoid these pitfalls.

## Test plan

- [ ] Verify SKILL.md references the new files correctly
- [ ] Check TROUBLESHOOTING.md renders properly
- [ ] Check UUI-GOTCHAS.md renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)