### PR TITLE
Document UFM custom element sanitization requirements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Umbraco backoffice customization skills for Claude Code",
-    "version": "17.0.0-beta.10",
+    "version": "17.0.0-beta.11",
     "homepage": "https://github.com/hifi-phil/UmbracoCMS_Skills"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umbraco-cms-backoffice-skills",
       "source": "./plugins/umbraco-backoffice-skills",
       "description": "Umbraco backoffice skills covering Foundation, Extension Types, Property Editors, Rich Text, Backend, and Setup",
-      "version": "17.0.0-beta.10",
+      "version": "17.0.0-beta.11",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",

--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "17.0.0-beta.10",
+  "version": "17.0.0-beta.11",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-ufm-component/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-ufm-component/SKILL.md
@@ -79,6 +79,12 @@ export { MyUfmComponent as api };
 ```
 
 ### Component with Custom Element (my-ufm-component.ts)
+
+> **Important**: UFM's post-processing sanitizer only allows custom element
+> tag names that start with `umb-`, `ufm-`, or `uui-`. Any other prefix
+> (e.g. `my-hidden-label`) will be stripped from the rendered output.
+> See the [UFM sanitization docs](https://docs.umbraco.com/umbraco-cms/reference/umbraco-flavored-markdown#post-processing-and-sanitization).
+
 ```typescript
 import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -88,13 +94,14 @@ import type { UfmToken } from '@umbraco-cms/backoffice/ufm';
 // The UFM component that renders to custom element
 export class MyUfmComponent extends UmbUfmComponentBase {
   render(token: UfmToken): string | undefined {
-    // Output a custom element with the token text as attribute
-    return `<my-ufm-element text="${token.text}"></my-ufm-element>`;
+    // Output a custom element with the token text as attribute.
+    // Tag name MUST start with umb-, ufm-, or uui- to survive sanitization.
+    return `<ufm-my-element text="${token.text}"></ufm-my-element>`;
   }
 }
 
 // The custom element that gets rendered
-@customElement('my-ufm-element')
+@customElement('ufm-my-element')
 export class MyUfmElement extends UmbLitElement {
   @property()
   text?: string;
@@ -186,5 +193,7 @@ UFM components are used in label descriptions and markdown text:
 - Return safe HTML (escape user input)
 - Keep rendering lightweight
 - Consider accessibility in output
+- When rendering custom elements, use an allowed tag-name prefix: `umb-`,
+  `ufm-`, or `uui-`. Other prefixes are removed by UFM's sanitizer.
 
 That's it! Always fetch fresh docs, keep examples minimal, generate complete working code.

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-ufm-component/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-ufm-component/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: umbraco-ufm-component
 description: Implement UFM (Umbraco Flavored Markdown) components in Umbraco backoffice using official docs
-version: 1.0.0
+version: 1.0.1
 location: managed
 allowed-tools: Read, Write, Edit, WebFetch
 ---


### PR DESCRIPTION
## Summary
Updated the UFM component documentation to clarify sanitization rules for custom elements and provide corrected examples that follow the allowed tag-name prefixes.

## Key Changes
- Added an important notice explaining that UFM's post-processing sanitizer only allows custom element tag names starting with `umb-`, `ufm-`, or `uui-`
- Updated the code example to use `ufm-my-element` instead of `my-ufm-element` to demonstrate the correct naming convention
- Added a link to the UFM sanitization documentation for reference
- Updated inline code comments to clarify the tag-name requirement
- Added sanitization guidance to the best practices section

## Implementation Details
The changes ensure developers understand that custom elements with other prefixes (e.g., `my-hidden-label`) will be stripped from the rendered output. The example now demonstrates the correct approach by using the `ufm-` prefix, which is one of the three allowed prefixes for custom elements in UFM components.

https://claude.ai/code/session_01EgwFwfwTz5mqkFDRpd1z2P