### PR TITLE
Support worktrees without Umbraco host port clashes (v17)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,29 @@
 {
   "enabledPlugins": {
     "playwright@claude-plugins-official": true
+  },
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/worktree-create.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/worktree-remove.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
+++ b/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
@@ -48,7 +48,12 @@ interface TestableExample {
 }
 
 // Config
-const UMBRACO_URL = process.env.UMBRACO_URL || 'https://localhost:44325';
+// UMBRACO_URL is mutable: when we start the host ourselves and no URL was pinned, we learn
+// the real URL from the boot log ("Now listening on: …"). This lets worktrees run the host
+// on an OS-assigned dynamic port (launchSettings rewritten to :0) without clashing — see
+// scripts/worktree-create.sh. An explicitly-set UMBRACO_URL is always honoured as-is.
+let UMBRACO_URL = process.env.UMBRACO_URL || 'https://localhost:44325';
+const UMBRACO_URL_EXPLICIT = !!process.env.UMBRACO_URL;
 const UMBRACO_PROJECT_PATH = join(PROJECT_ROOT, 'Umbraco-CMS.Skills');
 const TEST_TIMEOUT_UNIT = 60000;
 const TEST_TIMEOUT_MOCKED = 120000;
@@ -151,14 +156,36 @@ async function waitForUmbraco(url: string, timeout: number): Promise<boolean> {
 }
 
 /**
+ * True if the host's launchSettings uses a dynamic (OS-assigned) port — i.e. this is a
+ * worktree whose launchSettings.json was rewritten to :0 (see scripts/worktree-create.sh).
+ * In that case we must NOT reuse whatever is on the default port (it'd be another checkout's
+ * host) — we always start our own and discover its URL from the boot log.
+ */
+function hostUsesDynamicPort(): boolean {
+  try {
+    const ls = readFileSync(join(UMBRACO_PROJECT_PATH, 'Properties', 'launchSettings.json'), 'utf-8');
+    const appUrl = JSON.parse(ls)?.profiles?.['Umbraco.Web.UI']?.applicationUrl ?? '';
+    return /:0(?:$|;|\/)/.test(appUrl);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Start Umbraco if not running
  */
 async function ensureUmbracoRunning(): Promise<boolean> {
-  // Check if already running
-  const running = await checkUmbracoHealth(UMBRACO_URL);
-  if (running) {
-    console.error(`Umbraco already running at ${UMBRACO_URL}`);
-    return false;
+  const dynamicPort = !UMBRACO_URL_EXPLICIT && hostUsesDynamicPort();
+
+  // Reuse an already-running host only when we know its URL for certain: an explicit
+  // UMBRACO_URL, or the fixed default port in a normal checkout. Never reuse in a worktree
+  // (dynamic port) — that host belongs to another checkout.
+  if (!dynamicPort) {
+    const running = await checkUmbracoHealth(UMBRACO_URL);
+    if (running) {
+      console.error(`Umbraco already running at ${UMBRACO_URL}`);
+      return false;
+    }
   }
 
   // Check if project exists
@@ -167,7 +194,7 @@ async function ensureUmbracoRunning(): Promise<boolean> {
     return false;
   }
 
-  console.error(`Starting Umbraco from ${UMBRACO_PROJECT_PATH}...`);
+  console.error(`Starting Umbraco from ${UMBRACO_PROJECT_PATH}${dynamicPort ? ' (dynamic port)' : ''}...`);
 
   // Start Umbraco
   umbracoProcess = spawn('dotnet', ['run'], {
@@ -176,14 +203,36 @@ async function ensureUmbracoRunning(): Promise<boolean> {
     detached: true
   });
 
-  // Log output for debugging
+  // Discover the real base URL from the boot log ("Now listening on: https://127.0.0.1:PORT").
+  // Essential when the port is dynamic; a harmless confirmation of the default otherwise.
+  let resolveListening: (url: string) => void = () => {};
+  const listeningUrl = new Promise<string>((res) => { resolveListening = res; });
   umbracoProcess.stdout?.on('data', (data) => {
-    console.error(`[Umbraco] ${data.toString().trim()}`);
+    const text = data.toString();
+    console.error(`[Umbraco] ${text.trim()}`);
+    const match = text.match(/Now listening on:\s*(https:\/\/\S+)/i);
+    if (match) resolveListening(match[1].replace(/\/+$/, ''));
   });
 
   umbracoProcess.stderr?.on('data', (data) => {
     console.error(`[Umbraco Error] ${data.toString().trim()}`);
   });
+
+  // When the URL isn't pinned, wait for the boot log to reveal it before health-checking.
+  if (!UMBRACO_URL_EXPLICIT) {
+    const discovered = await Promise.race([
+      listeningUrl,
+      new Promise<null>((res) => setTimeout(() => res(null), UMBRACO_STARTUP_TIMEOUT)),
+    ]);
+    if (discovered) {
+      UMBRACO_URL = discovered;
+      console.error(`Discovered Umbraco URL: ${UMBRACO_URL}`);
+    } else if (dynamicPort) {
+      console.error('Could not discover the dynamic Umbraco URL from the boot log — aborting host start.');
+      stopUmbraco();
+      return false;
+    }
+  }
 
   // Wait for ready
   const ready = await waitForUmbraco(UMBRACO_URL, UMBRACO_STARTUP_TIMEOUT);

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ lerna-debug.log*
 validation-report.json
 code-analysis-report.json
 test-report.json
+
+# Worktree directories
+.claude/worktrees/

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example/Client/tests/mock-repo/playwright.config.ts
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example/Client/tests/mock-repo/playwright.config.ts
@@ -14,8 +14,9 @@ if (!UMBRACO_CLIENT_PATH) {
   throw new Error('UMBRACO_CLIENT_PATH environment variable is required. See .env.example');
 }
 
-// Use port 5175 to avoid conflict with other dev servers
-const DEV_SERVER_PORT = 5175;
+// Use port 5175 to avoid conflict with other dev servers.
+// Overridable (DEV_SERVER_PORT env) so concurrent worktrees don't clash on this port.
+const DEV_SERVER_PORT = Number(process.env.DEV_SERVER_PORT) || 5175;
 
 /**
  * Playwright Configuration for Mock Repository Tests

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example/Client/tests/msw/playwright.config.ts
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example/Client/tests/msw/playwright.config.ts
@@ -14,8 +14,9 @@ if (!UMBRACO_CLIENT_PATH) {
 	throw new Error('UMBRACO_CLIENT_PATH environment variable is required. See .env.example');
 }
 
-// Use port 5176 to avoid conflict with other dev servers
-const DEV_SERVER_PORT = 5176;
+// Use port 5176 to avoid conflict with other dev servers.
+// Overridable (DEV_SERVER_PORT env) so concurrent worktrees don't clash on this port.
+const DEV_SERVER_PORT = Number(process.env.DEV_SERVER_PORT) || 5176;
 
 /**
  * Playwright Configuration for MSW (Mock Service Worker) Tests

--- a/plugins/umbraco-testing-skills/skills/umbraco-example-generator/examples/workspace-feature-toggle/tests/playwright.config.ts
+++ b/plugins/umbraco-testing-skills/skills/umbraco-example-generator/examples/workspace-feature-toggle/tests/playwright.config.ts
@@ -13,8 +13,9 @@ const EXTENSION_PATH = resolve(__dirname, '..');
 const UMBRACO_CLIENT_PATH = process.env.UMBRACO_CLIENT_PATH ||
 	'/Users/philw/Projects/Umbraco-CMS/src/Umbraco.Web.UI.Client';
 
-// Use port 5174 to avoid conflict with other dev servers
-const DEV_SERVER_PORT = 5174;
+// Use port 5174 to avoid conflict with other dev servers.
+// Overridable (DEV_SERVER_PORT env) so concurrent worktrees don't clash on this port.
+const DEV_SERVER_PORT = Number(process.env.DEV_SERVER_PORT) || 5174;
 
 /**
  * Playwright Configuration for Workspace Feature Toggle Mocked Tests

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Claude Code WorktreeCreate hook.
+#
+# Input (stdin JSON):  { "name": "<slug>", "cwd": "<project-root>" }
+# Output (stdout):     the worktree path on the LAST line (Claude Code reads it).
+#                      All diagnostics go to stderr.
+#
+# What it does — and why:
+# The repo ships a real Umbraco host (Umbraco-CMS.Skills/) that binds a fixed port
+# (https 44325 / http 60290, from Properties/launchSettings.json). Two checkouts running
+# that host at once would collide on those ports. So for each worktree we rewrite its
+# launchSettings.json to port 0 — the OS then hands out a free ephemeral port, so every
+# worktree's instance (and the primary checkout) can run simultaneously without clashing.
+# The test-runner discovers the actual port from the "Now listening on" boot log.
+#
+# The host dir is committed (a worktree gets it for free) and uses SQLite with a gitignored
+# DB file, so — unlike a shared SQL Server setup — there is no DB to copy or provision:
+# each worktree does its own unattended install into its own DB file on first boot.
+
+INPUT=$(cat)
+NAME=$(echo "$INPUT" | jq -r '.name // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+if [ -z "$NAME" ]; then
+  echo "Error: no name provided" >&2
+  exit 1
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${CWD:-$(git rev-parse --show-toplevel)}}"
+
+# Directory slug: replace / with -. Branch: use as-is if it has a /, else prefix feature/.
+DIR_SLUG=$(echo "$NAME" | tr '/' '-')
+if [[ "$NAME" == *"/"* ]]; then
+  BRANCH_NAME="$NAME"
+else
+  BRANCH_NAME="feature/$NAME"
+fi
+
+WORKTREE_PATH="$PROJECT_DIR/.claude/worktrees/$DIR_SLUG"
+
+# --- Detect base branch ---
+git -C "$PROJECT_DIR" fetch origin 2>/dev/null || true
+BASE_BRANCH=""
+for candidate in main master dev; do
+  if git -C "$PROJECT_DIR" rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
+    BASE_BRANCH="origin/$candidate"
+    break
+  fi
+done
+if [ -z "$BASE_BRANCH" ]; then
+  echo "Error: could not find base branch (main, master, or dev)" >&2
+  exit 1
+fi
+echo "Base branch: $BASE_BRANCH" >&2
+
+# --- Handle existing worktree ---
+if [ -d "$WORKTREE_PATH" ]; then
+  echo "Worktree already exists at $WORKTREE_PATH" >&2
+  echo "$WORKTREE_PATH"
+  exit 0
+fi
+
+# --- Create worktree ---
+mkdir -p "$(dirname "$WORKTREE_PATH")"
+if git -C "$PROJECT_DIR" rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
+  echo "Using existing local branch: $BRANCH_NAME" >&2
+  git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" "$BRANCH_NAME" >&2
+elif git -C "$PROJECT_DIR" rev-parse --verify "origin/$BRANCH_NAME" >/dev/null 2>&1; then
+  echo "Tracking remote branch: origin/$BRANCH_NAME" >&2
+  git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" --track "origin/$BRANCH_NAME" >&2
+else
+  echo "Creating new branch: $BRANCH_NAME from $BASE_BRANCH" >&2
+  git -C "$PROJECT_DIR" worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" "$BASE_BRANCH" >&2
+fi
+
+# --- Rewrite the host's launchSettings.json to use a dynamic (OS-assigned) port ---
+# port 0 => the OS picks a free port at boot, so this worktree's Umbraco instance never
+# clashes with the primary checkout or other worktrees. The test-runner reads the real
+# URL from the "Now listening on" boot log, so nothing needs to know the port in advance.
+LAUNCH_SETTINGS="$WORKTREE_PATH/Umbraco-CMS.Skills/Properties/launchSettings.json"
+if [ -f "$LAUNCH_SETTINGS" ]; then
+  jq '
+    .profiles["Umbraco.Web.UI"].applicationUrl = "https://127.0.0.1:0;http://127.0.0.1:0" |
+    .iisSettings.iisExpress.sslPort = 0 |
+    .iisSettings.iisExpress.applicationUrl = "http://127.0.0.1:0"
+  ' "$LAUNCH_SETTINGS" > "$LAUNCH_SETTINGS.tmp" && mv "$LAUNCH_SETTINGS.tmp" "$LAUNCH_SETTINGS"
+  echo "Rewrote Umbraco-CMS.Skills launchSettings.json to a dynamic port (0)" >&2
+  echo "  (this is a local-only edit in the worktree — do not commit it)" >&2
+else
+  echo "Warning: launchSettings.json not found at $LAUNCH_SETTINGS — port not made dynamic" >&2
+fi
+
+# --- Ensure worktrees are gitignored ---
+GITIGNORE="$PROJECT_DIR/.gitignore"
+if [ -f "$GITIGNORE" ] && ! grep -q '.claude/worktrees/' "$GITIGNORE"; then
+  { echo ""; echo "# Worktree directories"; echo ".claude/worktrees/"; } >> "$GITIGNORE"
+  echo "Added .claude/worktrees/ to .gitignore" >&2
+fi
+
+# Output the worktree path (Claude Code reads the last stdout line).
+echo "$WORKTREE_PATH"

--- a/scripts/worktree-remove.sh
+++ b/scripts/worktree-remove.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Claude Code WorktreeRemove hook.
+#
+# Input (stdin JSON): { "worktree_path": "<absolute-path>" }
+#
+# Kills anything still rooted in / holding files under the worktree (a `dotnet run` host,
+# its compiled binary, a vite dev server from the mocked suites, a Playwright browser, etc.)
+# before removing the worktree — otherwise `git worktree remove` fails on a busy directory.
+
+INPUT=$(cat)
+WORKTREE_PATH=$(echo "$INPUT" | jq -r '.worktree_path // empty')
+
+if [ -z "$WORKTREE_PATH" ]; then
+  echo "Error: no worktree_path provided" >&2
+  exit 1
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo "")}"
+DIR_SLUG=$(basename "$WORKTREE_PATH")
+echo "Removing worktree: $DIR_SLUG" >&2
+
+# --- Kill anything holding the worktree ---
+#   1. Anything whose argv mentions the worktree path (pgrep -f)
+#   2. Anything with open file handles inside the worktree (lsof +D)
+#   3. The compiled host binary path (covers re-parented orphans)
+kill_holders() {
+  local signal="$1" pids
+  pids=$( {
+    pgrep -f "$WORKTREE_PATH" 2>/dev/null
+    lsof -t +D "$WORKTREE_PATH" 2>/dev/null
+    pgrep -f "$WORKTREE_PATH/Umbraco-CMS.Skills/bin/" 2>/dev/null
+  } | sort -u | tr '\n' ' ')
+  if [ -n "$pids" ]; then
+    echo "Sending $signal to: $pids" >&2
+    echo "$pids" | xargs kill -"$signal" 2>/dev/null || true
+    return 0
+  fi
+  return 1
+}
+
+if kill_holders TERM; then
+  sleep 2
+  kill_holders KILL >/dev/null 2>&1 || true
+  sleep 1
+fi
+
+# --- Remove worktree ---
+if [ -n "$PROJECT_DIR" ]; then
+  git -C "$PROJECT_DIR" worktree remove --force "$WORKTREE_PATH" 2>/dev/null || {
+    echo "Force remove failed, trying prune + rm..." >&2
+    git -C "$PROJECT_DIR" worktree prune 2>/dev/null || true
+    rm -rf "$WORKTREE_PATH" 2>/dev/null || true
+  }
+else
+  rm -rf "$WORKTREE_PATH" 2>/dev/null || true
+fi
+
+echo "Worktree $DIR_SLUG removed" >&2


### PR DESCRIPTION
Backport of #81 to the **v17 line**.

## What & why

Creating a Claude Code worktree previously meant the worktree's Umbraco host (`Umbraco-CMS.Skills/`) collided with the primary checkout on the fixed `44325`/`60290` ports. This adds worktree lifecycle hooks so a worktree's host runs alongside the primary checkout (and other worktrees) with **no port clash**.

## How

- **`scripts/worktree-create.sh`** (WorktreeCreate hook): creates the worktree and rewrites its `Umbraco-CMS.Skills/Properties/launchSettings.json` to port `0`, so the OS assigns a free ephemeral port instead of `44325`/`60290`.
- **`scripts/worktree-remove.sh`** (WorktreeRemove hook): kills any process still holding the worktree, then `git worktree remove`.
- **`.claude/settings.json`**: wires the two hooks.
- **`run-tests.ts`**: discovers the real host URL from the `Now listening on: …` boot log and never reuses another checkout's host when the port is dynamic — so validation works inside a worktree.
- **Mocked `playwright.config.ts` (×3)**: `DEV_SERVER_PORT` is now env-overridable so concurrent worktrees don't clash on the client dev-server port.
- **`.gitignore`**: `.claude/worktrees/`.

## Differences from the v18 PR (#81)

- **No `CLAUDE.md` change** — the v17 line has no `CLAUDE.md`.
- **v17 mechanism preserved** — the mocked configs keep v17's `VITE_EXTERNAL_EXTENSION … dev:external` dev server; only the port was made overridable. No v18-only test-runner changes were pulled in.

## Verified

Live hook cycle on the v17 base: create rewrites `launchSettings` to `:0`, remove tears the worktree down cleanly; the runner parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)