### PR TITLE
Port notes-wiki section-access composer to v18

### DIFF
--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/notes-wiki/Composers/EnsureNotesSectionAccessComposer.cs
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/notes-wiki/Composers/EnsureNotesSectionAccessComposer.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace NotesWiki.Composers;
+
+/// <summary>
+/// A custom backoffice <c>section</c> is only shown to users whose user group is allowed to
+/// access it. A fresh Umbraco install does not grant custom sections to any group, so without
+/// this the "Notes" section would be invisible even to administrators until someone adds it
+/// manually under Users &gt; User Groups &gt; Administrators &gt; Sections.
+///
+/// This composer wires a startup handler that grants the Notes section to the Administrators
+/// group once, so the example works out-of-the-box on any (including unattended) install.
+///
+/// Skills used: umbraco-sections, umbraco-controllers (composers/notifications)
+/// </summary>
+public class EnsureNotesSectionAccessComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, EnsureNotesSectionAccessHandler>();
+}
+
+/// <summary>
+/// Grants the Notes section to the Administrators user group on application start (idempotent).
+/// </summary>
+public class EnsureNotesSectionAccessHandler : INotificationAsyncHandler<UmbracoApplicationStartedNotification>
+{
+    // Must match NOTES_SECTION_ALIAS in Client/src/section/constants.ts.
+    private const string NotesSectionAlias = "Notes.Section";
+
+    private readonly IUserGroupService _userGroupService;
+    private readonly ILogger<EnsureNotesSectionAccessHandler> _logger;
+
+    public EnsureNotesSectionAccessHandler(
+        IUserGroupService userGroupService,
+        ILogger<EnsureNotesSectionAccessHandler> logger)
+    {
+        _userGroupService = userGroupService;
+        _logger = logger;
+    }
+
+    public async Task HandleAsync(UmbracoApplicationStartedNotification notification, CancellationToken cancellationToken)
+    {
+        IUserGroup? adminGroup = await _userGroupService.GetAsync(Umbraco.Cms.Core.Constants.Security.AdminGroupAlias);
+        if (adminGroup is null || adminGroup.AllowedSections.Contains(NotesSectionAlias))
+        {
+            return;
+        }
+
+        adminGroup.AddAllowedSection(NotesSectionAlias);
+        Attempt<IUserGroup, UserGroupOperationStatus> result =
+            await _userGroupService.UpdateAsync(adminGroup, Umbraco.Cms.Core.Constants.Security.SuperUserKey);
+
+        if (result.Success)
+        {
+            _logger.LogInformation("Granted the '{Section}' section to the '{Group}' user group.", NotesSectionAlias, Umbraco.Cms.Core.Constants.Security.AdminGroupAlias);
+        }
+        else
+        {
+            _logger.LogWarning("Could not grant the '{Section}' section to the '{Group}' user group: {Status}.", NotesSectionAlias, Umbraco.Cms.Core.Constants.Security.AdminGroupAlias, result.Status);
+        }
+    }
+}


### PR DESCRIPTION
## What

Forward-ports `EnsureNotesSectionAccessComposer.cs` to the notes-wiki example on `main` (v18). It was added to the v17 line in #83 but never made it onto `main` — the v18 upgrade (#80) predated it.

The composer grants the custom **Notes** section to the Administrators group on application start (idempotent). Without it, a custom section is invisible even to administrators on a fresh/unattended install until someone manually adds it under *Users → User Groups → Administrators → Sections* — so the notes-wiki example silently appears broken out-of-the-box.

## Why it applies cleanly to v18

Uses only stock APIs (`IUserGroupService`, `UmbracoApplicationStartedNotification`) that are unchanged between v17 and v18. The section alias it depends on (`Notes.Section`) already matches main's `Client/src/section/constants.ts`. The example `.csproj` uses SDK-style implicit `.cs` globbing, so no project changes are needed.

## Verification

- `dotnet build` of the host against v18 — **0 errors** (only pre-existing NU1903 advisory warnings).
- Runtime: booted the host, revoked `Notes.Section` from the admin group in the DB, restarted, and confirmed the handler re-granted it and logged:
  `Granted the 'Notes.Section' section to the 'admin' user group.`
- Confirmed `Notes.Section` is back in `umbracoUserGroup2App` for the admin group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)