### PR TITLE
feat: version-guard preflight to prevent v17/v18 skill confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Experimental Beta:** This project is an exploration of what's possible with Skills for Umbraco. It's evolving as we learn what works best.
 
-A Claude Code plugin marketplace with 66 skills for Umbraco backoffice customization and testing.
+A Claude Code plugin marketplace with 67 skills for Umbraco backoffice customization and testing.
 
 ## Quick Start
 
@@ -13,12 +13,37 @@ Add the marketplace:
 
 Install the plugins:
 ```bash
-# Backoffice extension skills (58 skills)
+# Backoffice extension skills (59 skills)
 /plugin install umbraco-cms-backoffice-skills@umbraco-backoffice-marketplace
 
 # Testing skills (8 skills) - optional but recommended
 /plugin install umbraco-cms-backoffice-testing-skills@umbraco-backoffice-marketplace
 ```
+
+---
+
+## ⚠️ Match the skills to your Umbraco version (17 vs 18)
+
+**These skills are versioned to a single Umbraco major.** The backoffice API differs
+between majors (tree data sources, auth, OpenAPI registration, and more), so loading the
+wrong line produces confidently-incorrect code. Pick the line that matches **your site**:
+
+| Your site is… | Skills line | Install command |
+|---|---|---|
+| **Umbraco 18** (current) | `main` (default) | `/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills` |
+| **Umbraco 17** | `v17/main` branch | `/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v17/main` |
+
+For the **Vercel Skills CLI** (Cursor/Copilot/Windsurf), point at the `v17/main` branch in
+the repo URL for v17, e.g. `.../Umbraco-CMS-Backoffice-Skills/tree/v17/main/...`.
+
+**Not sure which major your site is?** Check the `Umbraco.Cms` version in your project's
+`.csproj`, or the `@umbraco-cms/backoffice` version in your `Client/package.json`.
+
+**Automatic safety net:** the `umbraco-version-guard` skill runs as a preflight inside the
+entry skills (`umbraco-quickstart`, `umbraco-backoffice`, `umbraco-extension-template`).
+It detects your site's major and **stops with a warning if it doesn't match the loaded
+skills**, so a mismatch can't silently produce wrong code. You can also run it directly
+with `/umbraco-version-guard`.
 
 ---
 
@@ -42,7 +67,7 @@ npx skills add umbraco/Umbraco-CMS-Backoffice-Skills --skill '*' -a windsurf
 
 Or install each skill set separately:
 ```bash
-# Backoffice extension skills (58 skills)
+# Backoffice extension skills (59 skills)
 npx skills add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills/tree/main/plugins/umbraco-backoffice-skills/skills -a cursor
 
 # Testing skills (8 skills) - optional but recommended
@@ -64,7 +89,7 @@ npx skills add umbraco/Umbraco-CMS-Backoffice-Skills --skill umbraco-dashboard -
 | **Windsurf** | Current | `.windsurf/skills/` |
 | **Claude Code** | Current (use Quick Start above) | `.claude/skills/` |
 
-All of these editors load skills **on-demand** — only the skill relevant to your current task is loaded into context, so installing all 66 skills won't affect performance.
+All of these editors load skills **on-demand** — only the skill relevant to your current task is loaded into context, so installing all 67 skills won't affect performance.
 
 ---
 
@@ -354,7 +379,7 @@ Umbraco-CMS-Backoffice-Skills/
 │   │   └── skills/
 │   │       ├── umbraco-dashboard/SKILL.md
 │   │       ├── umbraco-tree/SKILL.md
-│   │       └── ... (57 skills)
+│   │       └── ... (58 skills)
 │   └── umbraco-testing-skills/         # Plugin with 8 testing skills
 │       ├── .claude-plugin/plugin.json
 │       └── skills/

--- a/README.md
+++ b/README.md
@@ -22,28 +22,37 @@ Install the plugins:
 
 ---
 
-## ⚠️ Match the skills to your Umbraco version (17 vs 18)
+## ⚠️ Match the skills to your Umbraco major
 
-**These skills are versioned to a single Umbraco major.** The backoffice API differs
-between majors (tree data sources, auth, OpenAPI registration, and more), so loading the
-wrong line produces confidently-incorrect code. Pick the line that matches **your site**:
+**These skills are versioned to a single Umbraco major** (tree data sources, auth, OpenAPI
+registration and more differ between majors, so loading the wrong line produces
+confidently-incorrect code). Each major gets its own line, following one rule:
 
-| Your site is… | Skills line | Install command |
-|---|---|---|
-| **Umbraco 18** (current) | `main` (default) | `/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills` |
-| **Umbraco 17** | `v17/main` branch | `/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v17/main` |
+- **The default `main` branch always targets the latest supported major.**
+- **Older majors live on a `vN/main` branch** (e.g. `v17/main`).
 
-For the **Vercel Skills CLI** (Cursor/Copilot/Windsurf), point at the `v17/main` branch in
-the repo URL for v17, e.g. `.../Umbraco-CMS-Backoffice-Skills/tree/v17/main/...`.
+So pick your install by your site's major:
+
+| Your site is… | Install command |
+|---|---|
+| **The latest major** (whatever `main` currently targets) | `/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills` |
+| **An older major `N`** | `/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#vN/main` |
+
+> _Currently `main` targets Umbraco 18, and `v17/main` is available for Umbraco 17. When a
+> new major ships, `main` moves to it and the previous major moves to its own `vN/main`._
+
+For the **Vercel Skills CLI** (Cursor/Copilot/Windsurf), point the repo URL at the matching
+branch — `main` for the latest major, or `.../tree/vN/main/...` for an older one.
 
 **Not sure which major your site is?** Check the `Umbraco.Cms` version in your project's
 `.csproj`, or the `@umbraco-cms/backoffice` version in your `Client/package.json`.
 
 **Automatic safety net:** the `umbraco-version-guard` skill runs as a preflight inside the
-entry skills (`umbraco-quickstart`, `umbraco-backoffice`, `umbraco-extension-template`).
-It detects your site's major and **stops with a warning if it doesn't match the loaded
-skills**, so a mismatch can't silently produce wrong code. You can also run it directly
-with `/umbraco-version-guard`.
+entry skills (`umbraco-quickstart`, `umbraco-backoffice`, `umbraco-extension-template`). It
+derives the major these skills target from the plugin itself, detects your site's major,
+and **stops with a warning if they don't match** — so a mismatch can't silently produce
+wrong code, and the check stays correct as new majors ship. Run it directly any time with
+`/umbraco-version-guard`.
 
 ---
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
@@ -28,8 +28,8 @@ For details on individual extension types, invoke the referenced sub-skills.
 **CRITICAL**: This workflow is MANDATORY for ALL extension development.
 
 **Step 0 — Version guard:** Before planning, invoke `umbraco-version-guard` to confirm
-the site's Umbraco major matches these skills (this line targets **v18**). Stop on a
-mismatch — v17 and v18 backoffice APIs differ and these skills will produce wrong code.
+the site's Umbraco major matches the major these skills target. Stop on a mismatch — the
+backoffice API differs between Umbraco majors and these skills will produce wrong code.
 
 ```
 1. PLAN ──► Read PRE-BUILD-PLANNING.md FIRST

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
@@ -27,6 +27,10 @@ For details on individual extension types, invoke the referenced sub-skills.
 
 **CRITICAL**: This workflow is MANDATORY for ALL extension development.
 
+**Step 0 — Version guard:** Before planning, invoke `umbraco-version-guard` to confirm
+the site's Umbraco major matches these skills (this line targets **v18**). Stop on a
+mismatch — v17 and v18 backoffice APIs differ and these skills will produce wrong code.
+
 ```
 1. PLAN ──► Read PRE-BUILD-PLANNING.md FIRST
    │        Draw wireframe, label extension types, identify UUI components

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-extension-template/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-extension-template/SKILL.md
@@ -26,7 +26,7 @@ Always fetch the latest docs before implementing:
 ## Workflow
 
 0. **Version guard**: Invoke `umbraco-version-guard` first to confirm the target site's
-   Umbraco major matches these skills (this line targets **v18**). Stop on a mismatch.
+   Umbraco major matches the major these skills target. Stop on a mismatch.
 1. **Install template** (one-time): `dotnet new install Umbraco.Templates`
 2. **Create extension**: `dotnet new umbraco-extension -n MyExtension`
 3. **Install dependencies**: `cd MyExtension/Client && npm install`

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-extension-template/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-extension-template/SKILL.md
@@ -25,6 +25,8 @@ Always fetch the latest docs before implementing:
 
 ## Workflow
 
+0. **Version guard**: Invoke `umbraco-version-guard` first to confirm the target site's
+   Umbraco major matches these skills (this line targets **v18**). Stop on a mismatch.
 1. **Install template** (one-time): `dotnet new install Umbraco.Templates`
 2. **Create extension**: `dotnet new umbraco-extension -n MyExtension`
 3. **Install dependencies**: `cd MyExtension/Client && npm install`

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -41,8 +41,8 @@ If arguments not provided, check what exists and prompt for missing names.
 ### 2. Check what exists
 
 **Version guard (run first):** Before building anything, invoke `umbraco-version-guard`
-to confirm the site's Umbraco major matches these skills (this line targets **v18**). On
-a mismatch, stop and point the user at the matching skill line — do not generate code.
+to confirm the site's Umbraco major matches the major these skills target. On a mismatch,
+stop and point the user at the matching skill line — do not generate code.
 
 **Check for Umbraco instance:**
 ```bash

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -40,6 +40,10 @@ If arguments not provided, check what exists and prompt for missing names.
 
 ### 2. Check what exists
 
+**Version guard (run first):** Before building anything, invoke `umbraco-version-guard`
+to confirm the site's Umbraco major matches these skills (this line targets **v18**). On
+a mismatch, stop and point the user at the matching skill line — do not generate code.
+
 **Check for Umbraco instance:**
 ```bash
 find . -name "*.csproj" -exec grep -l "Umbraco.Cms" {} \; 2>/dev/null | head -5

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-version-guard/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-version-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: umbraco-version-guard
-description: Deterministically verify that the Umbraco major version of the site you are working on matches the major these skills target (this line targets Umbraco 18). Run this FIRST, before any Umbraco backoffice work, to avoid mixing v17 and v18 guidance. Trigger on the first Umbraco task in a session, or whenever the site's version is uncertain.
+description: Deterministically verify that the Umbraco major of the site you are working on matches the major these skills target. Run this FIRST, before any Umbraco backoffice work, to avoid mixing guidance across Umbraco majors (e.g. 17 vs 18 vs 19). Trigger on the first Umbraco task in a session, or whenever the site's version is uncertain.
 version: 1.0.0
 location: managed
 allowed-tools: Bash, Read, Grep, Glob, WebFetch
@@ -11,40 +11,41 @@ user_invocable: true
 
 ## What this skill does
 
-The Umbraco backoffice API changes between majors (v17 → v18 changed tree data
-sources, auth, OpenAPI registration, and more). **These skills target one specific
-major.** Applying them to a site on a different major produces confidently-wrong code.
+The Umbraco backoffice API changes between majors (tree data sources, auth, OpenAPI
+registration, and more). **These skills target one specific major.** Applying them to a
+site on a different major produces confidently-wrong code.
 
-This skill is a **preflight check**: it determines the target site's Umbraco major
-deterministically and compares it to the major these skills target. On a mismatch it
-STOPS and tells the user to install the matching skill line — it does not guess.
+This skill is a **preflight check**: it derives the target major from the plugin itself
+(so it never goes stale as new majors ship), detects the target site's major
+deterministically, compares them, and STOPS with the correct install command on a
+mismatch. Nothing here hardcodes a specific major number — both sides are computed.
 
-## The major these skills target
+## Step 1 — Determine the major these skills target
 
-> **This skill line targets Umbraco `18`.**
-
-That number is the single source of truth for this branch. (The `v17/main` branch ships
-its own copy of this skill stating `17`.) You can cross-check it against the installed
-plugin's version when available:
+The plugin's own version is the source of truth, and it bumps every major at release. Read
+it and take the leading number:
 
 ```bash
-# Optional confirmation — the plugin's own major. First path works when installed as a
-# Claude Code plugin; second when the skill was copied into an editor's skills dir.
-cat "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null | grep -m1 '"version"' \
-  || grep -m1 '"version"' ../../.claude-plugin/plugin.json 2>/dev/null
+# Primary: the installed plugin's version. First path is the Claude Code plugin layout;
+# the greps are fallbacks for when the skill was copied flat into an editor's skills dir.
+cat "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null \
+  || cat ../../.claude-plugin/plugin.json 2>/dev/null \
+  | grep -m1 '"version"' | grep -oE '[0-9]+' | head -1
 ```
 
-If that version's major disagrees with the `18` stated above, trust `plugin.json` and
-warn the user their install is inconsistent.
+Call this **TARGET_MAJOR**. If none of the paths resolve (a flat copy with no
+`plugin.json` alongside), fall back to the marketplace version, and only then to reading
+the value a sibling skill states — never invent a number. If you genuinely cannot
+determine it, say so and skip the guard rather than guessing.
 
-## Step 1 — Detect the site's Umbraco major (deterministic, no running instance needed)
+## Step 2 — Detect the site's Umbraco major (deterministic, no running instance needed)
 
-Try these signals in order and stop at the first that yields a number.
+Try these signals in order and stop at the first that yields a number. Each extracts just
+the **major**, so it works with `18.0.0`, `18.*`, `[18.0.0,)`, or plain `18`.
 
-**A. `Umbraco.Cms` package reference (ground truth — what is actually installed).**
-Extracts just the **major**, so it works with `18.0.0`, `18.*`, `[18.0.0,)`, or plain
-`18`. Covers `*.csproj` PackageReference and central-package-management `*.props`
-(PackageVersion); the trailing `"` after `Cms` excludes `Umbraco.Cms.DevelopmentMode` etc.
+**A. `Umbraco.Cms` package reference (ground truth — what is actually installed).** Covers
+`*.csproj` PackageReference and central-package-management `*.props` (PackageVersion); the
+trailing `"` after `Cms` excludes `Umbraco.Cms.DevelopmentMode` etc.
 
 ```bash
 grep -rhoE 'Umbraco\.Cms"[^0-9]*[0-9]+' --include='*.csproj' --include='*.props' . 2>/dev/null \
@@ -58,46 +59,48 @@ grep -rhoE '"@umbraco-cms/backoffice":[^0-9]*[0-9]+' --include='package.json' . 
   | grep -oE '[0-9]+$' | sort -u
 ```
 
-**C. Last resort — a running instance's Server Information API** (needs the site up; the
-`^` version may be an internal build number, so prefer A/B):
+**C. Last resort — a running instance's Server Information API** (needs the site up; prefer A/B):
 
 ```
 GET {baseUrl}/umbraco/management/api/v1/server/information
 ```
 
-Take the **major** (the first number) of whatever you find. If A/B/C all return nothing,
-there is no Umbraco site in the workspace yet — say so and continue (nothing to guard).
+Call the result **SITE_MAJOR**. If A/B/C all return nothing, there is no Umbraco site in
+the workspace yet — say so and continue (nothing to guard). If multiple different majors
+are found (a mixed solution), surface all of them and ask which project is the target.
 
-## Step 2 — Compare majors
+## Step 3 — Compare and act
 
-- **Site major == target major (18)** → ✅ Silent pass. Say one line confirming the match
-  (e.g. "Site is Umbraco 18.x — matches these skills.") and proceed with the task.
-- **Site major != target major** → ⛔ STOP. Do not generate version-specific code. Warn
-  as below.
-- **Multiple different majors detected** (e.g. a solution with mixed references) → surface
-  all of them and ask the user which project is the target before proceeding.
+- **`SITE_MAJOR == TARGET_MAJOR`** → ✅ Silent pass. Say one line confirming the match
+  (e.g. "Site is Umbraco {SITE_MAJOR}.x — matches these skills.") and proceed.
+- **`SITE_MAJOR != TARGET_MAJOR`** → ⛔ STOP. Do not generate version-specific code. Warn
+  as below, then only continue if the user explicitly confirms.
 
-## Step 3 — On mismatch, warn and point to the right line
+**Which skill line to recommend** follows the repo's branch convention — the *latest*
+major lives on `main`; every older major `N` lives on a `vN/main` branch:
 
-Tell the user plainly, then stop for their decision:
+- **`SITE_MAJOR < TARGET_MAJOR`** (site is older than these skills) → point at the older
+  line for the site's major:
+  ```
+  /plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v{SITE_MAJOR}/main
+  ```
+- **`SITE_MAJOR > TARGET_MAJOR`** (these skills are older than the site) → the latest major
+  lives on the default `main`, so re-add and update the default marketplace:
+  ```
+  /plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills
+  ```
+  If no released line exists yet for `SITE_MAJOR`, say so — the skills may not have caught
+  up to that major.
 
-> ⚠️ **Version mismatch.** This site is Umbraco **`<detected>`**, but the loaded skills
-> target Umbraco **18**. The backoffice API differs between these majors, so this skill
-> set will produce incorrect code for your site.
+Substitute the actual numbers when you present this. Template for the message:
+
+> ⚠️ **Version mismatch.** This site is Umbraco **{SITE_MAJOR}**, but the loaded skills
+> target Umbraco **{TARGET_MAJOR}**. The backoffice API differs between majors, so this
+> skill set will produce incorrect code for your site. Install the matching line:
+> `<computed command above>`
 >
-> Install the matching skill line instead:
->
-> - **Umbraco 18** (default / `main`):
->   ```
->   /plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills
->   ```
-> - **Umbraco 17** (`v17/main` branch):
->   ```
->   /plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v17/main
->   ```
->   Or, for the Vercel Skills CLI in other editors, add `#v17/main` to the repo URL.
-
-Only continue if the user explicitly confirms they understand and want to proceed anyway.
+> For the Vercel Skills CLI (Cursor/Copilot/Windsurf), point the repo URL at the matching
+> branch (`main` for the latest major, `v{N}/main` for an older one).
 
 ## When to run this
 

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-version-guard/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-version-guard/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: umbraco-version-guard
+description: Deterministically verify that the Umbraco major version of the site you are working on matches the major these skills target (this line targets Umbraco 18). Run this FIRST, before any Umbraco backoffice work, to avoid mixing v17 and v18 guidance. Trigger on the first Umbraco task in a session, or whenever the site's version is uncertain.
+version: 1.0.0
+location: managed
+allowed-tools: Bash, Read, Grep, Glob, WebFetch
+user_invocable: true
+---
+
+# Umbraco Version Guard
+
+## What this skill does
+
+The Umbraco backoffice API changes between majors (v17 → v18 changed tree data
+sources, auth, OpenAPI registration, and more). **These skills target one specific
+major.** Applying them to a site on a different major produces confidently-wrong code.
+
+This skill is a **preflight check**: it determines the target site's Umbraco major
+deterministically and compares it to the major these skills target. On a mismatch it
+STOPS and tells the user to install the matching skill line — it does not guess.
+
+## The major these skills target
+
+> **This skill line targets Umbraco `18`.**
+
+That number is the single source of truth for this branch. (The `v17/main` branch ships
+its own copy of this skill stating `17`.) You can cross-check it against the installed
+plugin's version when available:
+
+```bash
+# Optional confirmation — the plugin's own major. First path works when installed as a
+# Claude Code plugin; second when the skill was copied into an editor's skills dir.
+cat "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null | grep -m1 '"version"' \
+  || grep -m1 '"version"' ../../.claude-plugin/plugin.json 2>/dev/null
+```
+
+If that version's major disagrees with the `18` stated above, trust `plugin.json` and
+warn the user their install is inconsistent.
+
+## Step 1 — Detect the site's Umbraco major (deterministic, no running instance needed)
+
+Try these signals in order and stop at the first that yields a number.
+
+**A. `Umbraco.Cms` package reference (ground truth — what is actually installed).**
+Extracts just the **major**, so it works with `18.0.0`, `18.*`, `[18.0.0,)`, or plain
+`18`. Covers `*.csproj` PackageReference and central-package-management `*.props`
+(PackageVersion); the trailing `"` after `Cms` excludes `Umbraco.Cms.DevelopmentMode` etc.
+
+```bash
+grep -rhoE 'Umbraco\.Cms"[^0-9]*[0-9]+' --include='*.csproj' --include='*.props' . 2>/dev/null \
+  | grep -oE '[0-9]+$' | sort -u
+```
+
+**B. Fallback — the backoffice client dependency major** (handles `^18.0.0`, `~18.0.0`, `18.0.0`):
+
+```bash
+grep -rhoE '"@umbraco-cms/backoffice":[^0-9]*[0-9]+' --include='package.json' . 2>/dev/null \
+  | grep -oE '[0-9]+$' | sort -u
+```
+
+**C. Last resort — a running instance's Server Information API** (needs the site up; the
+`^` version may be an internal build number, so prefer A/B):
+
+```
+GET {baseUrl}/umbraco/management/api/v1/server/information
+```
+
+Take the **major** (the first number) of whatever you find. If A/B/C all return nothing,
+there is no Umbraco site in the workspace yet — say so and continue (nothing to guard).
+
+## Step 2 — Compare majors
+
+- **Site major == target major (18)** → ✅ Silent pass. Say one line confirming the match
+  (e.g. "Site is Umbraco 18.x — matches these skills.") and proceed with the task.
+- **Site major != target major** → ⛔ STOP. Do not generate version-specific code. Warn
+  as below.
+- **Multiple different majors detected** (e.g. a solution with mixed references) → surface
+  all of them and ask the user which project is the target before proceeding.
+
+## Step 3 — On mismatch, warn and point to the right line
+
+Tell the user plainly, then stop for their decision:
+
+> ⚠️ **Version mismatch.** This site is Umbraco **`<detected>`**, but the loaded skills
+> target Umbraco **18**. The backoffice API differs between these majors, so this skill
+> set will produce incorrect code for your site.
+>
+> Install the matching skill line instead:
+>
+> - **Umbraco 18** (default / `main`):
+>   ```
+>   /plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills
+>   ```
+> - **Umbraco 17** (`v17/main` branch):
+>   ```
+>   /plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v17/main
+>   ```
+>   Or, for the Vercel Skills CLI in other editors, add `#v17/main` to the repo URL.
+
+Only continue if the user explicitly confirms they understand and want to proceed anyway.
+
+## When to run this
+
+Run it **once at the start** of any Umbraco backoffice task, before writing code. The
+entry skills (`umbraco-quickstart`, `umbraco-backoffice`, `umbraco-extension-template`)
+reference this guard as their first step. Re-run only if the workspace changes.


### PR DESCRIPTION
## Why

The v17 and v18 skill lines share the same marketplace name and (nearly) the same install command, so it's easy to load the wrong one for a given site. The backoffice API differs across majors, so a mismatch produces confidently-incorrect code with no signal to the user.

## What

**New `umbraco-version-guard` skill** — a deterministic preflight that **hardcodes no specific major** (so it doesn't rot when 19+ ships):

- **Target major** is read from the plugin's own `plugin.json` version, which already bumps every major at release.
- **Site major** is detected from `Umbraco.Cms` in `*.csproj`/`*.props`, falling back to `@umbraco-cms/backoffice` in `package.json`, then the Server Information API. Major extraction handles `18.*`, `[18.0.0,)`, and plain `18`, and excludes `Umbraco.Cms.DevelopmentMode`. Verified against the repo's own host csproj (returns `18` from `18.*`).
- On mismatch it **stops** and shows the correct install command, **computed** from the branch convention (latest major on `main`, older majors on `vN/main`) — templated on the detected/target majors rather than enumerating v17/v18.

**Wired in as step 0** of the entry skills — `umbraco-quickstart`, `umbraco-backoffice`, `umbraco-extension-template` — so it runs before any code is written. Their preflight blurbs reference "the major these skills target", not a fixed number.

**README** — new "⚠️ Match the skills to your Umbraco major" section framed around the rule (default `main` = latest major; older majors on `vN/main`), with current majors shown only as an illustrative note so it stays true across releases. Skill counts bumped for the added skill.

## How it ages
When Umbraco 19 ships: `main`'s `plugin.json` becomes `19`, the 18 line moves to `v18/main`, and the guard keeps working with **zero edits** — target major follows `plugin.json`, and the recommended install command is derived from the branch convention.

## Notes
- No `plugin.json`/`marketplace.json` version bump — that's a release-time action per the repo's release process.
- Link validation: 0 broken URLs, 0 invalid paths; all `umbraco-version-guard` references resolve. Remaining warnings are the documented `umbraco-extension-reviewer` false positives (it's an agent, not a skill).

## Follow-up (separate PR)
Mirror the guard skill onto `v17/main` so the v17 line also carries it. (It needs no per-major editing thanks to the plugin.json-derived target.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)