### PR TITLE
ci: add GitHub Actions for skill validation

### DIFF
--- a/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
+++ b/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
@@ -73,9 +73,14 @@ const SUITE_TYPES: Set<TestType> = new Set(
     .map((s) => s.trim())
     .filter(Boolean) as TestType[]
 );
-const TEST_TIMEOUT_UNIT = 60000;
-const TEST_TIMEOUT_MOCKED = 120000;
-const TEST_TIMEOUT_E2E = 180000;
+// Per-suite wall-clock caps (safety net around each spawned test process). Overridable via
+// env because CI needs more headroom: Playwright suites set `retries: CI ? 2 : 0`, so a single
+// slow/flaky test can take timeout×3, and large suites (e.g. notes-wiki's 34 tests) legitimately
+// run longer than the local defaults. Too low a cap kills the suite mid-retry and masks the real
+// pass/fail as a generic "Test timed out".
+const TEST_TIMEOUT_UNIT = Number(process.env.UNIT_TIMEOUT_MS) || 60000;
+const TEST_TIMEOUT_MOCKED = Number(process.env.MOCKED_TIMEOUT_MS) || 120000;
+const TEST_TIMEOUT_E2E = Number(process.env.E2E_TIMEOUT_MS) || 180000;
 const UMBRACO_STARTUP_TIMEOUT = 120000;
 
 // Glob ignores shared by discovery and the orphan audit. Besides the usual build dirs, we

--- a/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
+++ b/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
@@ -78,6 +78,26 @@ const TEST_TIMEOUT_MOCKED = 120000;
 const TEST_TIMEOUT_E2E = 180000;
 const UMBRACO_STARTUP_TIMEOUT = 120000;
 
+// Glob ignores shared by discovery and the orphan audit. Besides the usual build dirs, we
+// must exclude the external Umbraco client checkout (UMBRACO_CLIENT_PATH) when it lands
+// INSIDE the repo tree — as it does in CI, where actions/checkout can only clone into the
+// workspace. That client ships its own examples/**/*.test.ts which would otherwise be
+// discovered as suites and flagged as orphans, failing the run with exit 2.
+function externalIgnoreGlobs(): string[] {
+  const ignores: string[] = [];
+  const clientPath = process.env.UMBRACO_CLIENT_PATH;
+  if (clientPath) {
+    const rel = relative(PROJECT_ROOT, resolve(clientPath));
+    // Only ignore when the client is under PROJECT_ROOT (rel doesn't escape upward).
+    if (rel && !rel.startsWith('..')) {
+      const top = rel.split('/')[0];
+      ignores.push(`${top}/**`);
+    }
+  }
+  return ignores;
+}
+const BASE_IGNORES = ['**/node_modules/**', '**/dist/**'];
+
 // Track Umbraco process if we start it
 let umbracoProcess: ChildProcess | null = null;
 let weStartedUmbraco = false;
@@ -88,7 +108,7 @@ let weStartedUmbraco = false;
 async function discoverTestableExamples(): Promise<TestableExample[]> {
   const packageFiles = await glob('**/examples/**/package.json', {
     cwd: PROJECT_ROOT,
-    ignore: ['**/node_modules/**', '**/dist/**']
+    ignore: [...BASE_IGNORES, ...externalIgnoreGlobs()]
   });
 
   const examples: TestableExample[] = [];
@@ -318,6 +338,18 @@ async function runTest(
   const startTime = Date.now();
   const exampleDir = join(PROJECT_ROOT, example.path);
 
+  // Playwright suites (mocked/e2e) launch a browser via the example's OWN pinned @playwright/test
+  // version — which differs across examples (1.49 / 1.56 / 1.57 …), each needing a different
+  // browser build. A single top-level `playwright install` can't satisfy them all, so install
+  // the right browser from within the example here (idempotent; fast when already cached).
+  if (test.type === 'mocked' || test.type === 'e2e') {
+    try {
+      execSync('npx playwright install chromium', { cwd: exampleDir, stdio: 'ignore' });
+    } catch {
+      console.error(`  Warning: playwright browser install failed in ${example.path} — suite may fail to launch`);
+    }
+  }
+
   // Determine timeout
   const timeout = test.type === 'unit' ? TEST_TIMEOUT_UNIT :
                   test.type === 'mocked' ? TEST_TIMEOUT_MOCKED : TEST_TIMEOUT_E2E;
@@ -429,7 +461,7 @@ async function auditTestCoverage(examples: TestableExample[]): Promise<OrphanTes
   // 2) Every spec/test file under examples/ should belong to an example that has a suite.
   const specFiles = await glob('**/examples/**/*.{spec,test}.ts', {
     cwd: PROJECT_ROOT,
-    ignore: ['**/node_modules/**', '**/dist/**', '**/test-results/**', '**/playwright-report/**']
+    ignore: [...BASE_IGNORES, '**/test-results/**', '**/playwright-report/**', ...externalIgnoreGlobs()]
   });
   const testableDirs = examples.filter(e => e.tests.length > 0).map(e => e.path);
   for (const spec of specFiles) {

--- a/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
+++ b/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
@@ -64,6 +64,15 @@ interface TestableExample {
 let UMBRACO_URL = process.env.UMBRACO_URL || 'https://localhost:44325';
 const UMBRACO_URL_EXPLICIT = !!process.env.UMBRACO_URL;
 const UMBRACO_PROJECT_PATH = join(PROJECT_ROOT, 'Umbraco-CMS.Skills');
+// SUITE_TYPES: optional comma-separated allow-list of suite types to run (e.g. "unit"
+// or "unit,mocked"). Defaults to all three. Lets CI run a cheap unit-only gate on every
+// PR without pulling in the mocked/E2E prerequisites (external client checkout, .NET host).
+const SUITE_TYPES: Set<TestType> = new Set(
+  (process.env.SUITE_TYPES ?? 'unit,mocked,e2e')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean) as TestType[]
+);
 const TEST_TIMEOUT_UNIT = 60000;
 const TEST_TIMEOUT_MOCKED = 120000;
 const TEST_TIMEOUT_E2E = 180000;
@@ -474,6 +483,7 @@ async function runTests(): Promise<TestReport> {
 
   for (const example of examples) {
     for (const test of example.tests) {
+      if (!SUITE_TYPES.has(test.type)) continue; // SUITE_TYPES allow-list (default: all)
       if (test.type === 'unit') {
         unitTests.push({ example, test });
       } else if (test.type === 'mocked') {
@@ -482,6 +492,9 @@ async function runTests(): Promise<TestReport> {
         e2eTests.push({ example, test });
       }
     }
+  }
+  if (SUITE_TYPES.size < 3) {
+    console.error(`Suite filter active (SUITE_TYPES): running only ${[...SUITE_TYPES].join(', ')}`);
   }
 
   // Run unit tests first

--- a/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
+++ b/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
@@ -343,16 +343,15 @@ async function runTest(
   const startTime = Date.now();
   const exampleDir = join(PROJECT_ROOT, example.path);
 
-  // Playwright suites (mocked/e2e) launch a browser via the example's OWN pinned @playwright/test
-  // version — which differs across examples (1.49 / 1.56 / 1.57 …), each needing a different
-  // browser build. A single top-level `playwright install` can't satisfy them all, so install
-  // the right browser from within the example here (idempotent; fast when already cached).
-  if (test.type === 'mocked' || test.type === 'e2e') {
-    try {
-      execSync('npx playwright install chromium', { cwd: exampleDir, stdio: 'ignore' });
-    } catch {
-      console.error(`  Warning: playwright browser install failed in ${example.path} — suite may fail to launch`);
-    }
+  // Every suite here launches a browser via the example's OWN pinned Playwright — mocked/e2e via
+  // @playwright/test, unit via @web/test-runner-playwright — and those versions differ across
+  // examples (1.49 / 1.56 / 1.57 …), each needing a different browser build. A single top-level
+  // `playwright install` can't satisfy them all, so install the right browser from within the
+  // example here (idempotent; fast when already cached).
+  try {
+    execSync('npx playwright install chromium', { cwd: exampleDir, stdio: 'ignore' });
+  } catch {
+    console.error(`  Warning: playwright browser install failed in ${example.path} — suite may fail to launch`);
   }
 
   // Determine timeout

--- a/.claude/skills/umbraco-skill-validator/scripts/validate-links.ts
+++ b/.claude/skills/umbraco-skill-validator/scripts/validate-links.ts
@@ -2,7 +2,7 @@
 
 import { readFileSync, existsSync, writeFileSync } from 'fs';
 import { glob } from 'glob';
-import { dirname, resolve, join } from 'path';
+import { dirname, resolve, join, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { retry, handleAll, ExponentialBackoff } from 'cockatiel';
 
@@ -65,6 +65,7 @@ const SKIP_URL_PATTERNS = [
   /^https?:\/\/example\.com/,
   /^https?:\/\/my-docs\.com/,  // Example placeholder
   /^http:\/\/www\.w3\.org/,     // XML namespaces
+  /[{}]/,                        // Template placeholders, e.g. {SITE_MAJOR} — not real URLs
 ];
 
 // Find all SKILL.md files
@@ -75,6 +76,17 @@ async function discoverSkills(basePath: string): Promise<string[]> {
     ignore: ['**/node_modules/**', '**/dist/**']
   });
   return files.map(f => join(basePath, f));
+}
+
+// Find all agent names (agents live as `<name>.md` under a plugin `agents/` dir). Agents are
+// referenced from SKILL.md like skills (e.g. `umbraco-extension-reviewer`) but aren't skills,
+// so they must join the known-names set or they'd be flagged as missing skills.
+async function discoverAgentNames(basePath: string): Promise<string[]> {
+  const files = await glob('**/agents/*.md', {
+    cwd: basePath,
+    ignore: ['**/node_modules/**', '**/dist/**']
+  });
+  return files.map(f => basename(f, '.md')).filter(Boolean);
 }
 
 // Extract links from content with line numbers
@@ -333,11 +345,14 @@ async function validate(): Promise<ValidationReport> {
   const skillPaths = await discoverSkills(basePath);
   console.error(`Found ${skillPaths.length} SKILL.md files`);
 
-  // Extract all skill names for reference checking
-  const allSkillNames = skillPaths.map(p => {
+  // Extract all skill names for reference checking, plus agent names (referenced the same
+  // way in SKILL.md but not skills themselves — e.g. umbraco-extension-reviewer).
+  const skillNames = skillPaths.map(p => {
     const dir = dirname(p);
     return dir.split('/').pop() || '';
   }).filter(Boolean);
+  const agentNames = await discoverAgentNames(basePath);
+  const allSkillNames = [...skillNames, ...agentNames];
 
   const stats: ValidationReport['statistics'] = {
     urlsChecked: 0,

--- a/.claude/skills/umbraco-skill-validator/scripts/validate-links.ts
+++ b/.claude/skills/umbraco-skill-validator/scripts/validate-links.ts
@@ -202,10 +202,14 @@ async function checkUmbracoPath(path: string): Promise<boolean> {
   // Fall back to GitHub API
   try {
     const apiPath = path.replace('/Umbraco-CMS/', '').replace(/^\//, '');
+    // Authenticate when a token is present (GITHUB_TOKEN is provided automatically in
+    // GitHub Actions). Raises the rate limit from 60 to 5000 req/hr so CI doesn't flake.
+    const ghToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
     const response = await fetch(`${GITHUB_API_BASE}/${apiPath}`, {
       headers: {
         'Accept': 'application/vnd.github.v3+json',
-        'User-Agent': 'skill-validator'
+        'User-Agent': 'skill-validator',
+        ...(ghToken ? { Authorization: `Bearer ${ghToken}` } : {})
       }
     });
     return response.status === 200;

--- a/.github/workflows/validate-full.yml
+++ b/.github/workflows/validate-full.yml
@@ -50,19 +50,22 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      # --- Build the external v18 client (needed by the mocked-backoffice suites) ---
-      - name: Checkout Umbraco-CMS client
-        uses: actions/checkout@v4
+      # --- Umbraco source (v18 client) needed by the mocked-backoffice suites. Cloned BESIDE the
+      # repo (under RUNNER_TEMP, outside GITHUB_WORKSPACE) and cached across runs, so nightly runs
+      # skip the slow clone + npm ci. Keeping it out of the workspace also keeps its own
+      # examples/**/*.test.ts out of the test runner's discovery/orphan audit.
+      - name: Cache Umbraco source
+        id: cache-umbraco
+        uses: actions/cache@v4
         with:
-          repository: umbraco/Umbraco-CMS
-          ref: ${{ env.CLIENT_REF }}
-          path: umbraco-cms
+          path: ${{ runner.temp }}/umbraco-cms
+          key: umbraco-src-${{ env.CLIENT_REF }}-v1
 
-      - name: Install client deps
-        working-directory: umbraco-cms/src/Umbraco.Web.UI.Client
-        # npm ci to match the lockfile exactly — an out-of-sync client renders a blank
-        # mocked page (uui-css -> static-copy -> msw 404). See repo notes.
-        run: npm ci
+      - name: Clone & install Umbraco client (cache miss)
+        if: steps.cache-umbraco.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "$CLIENT_REF" https://github.com/umbraco/Umbraco-CMS "$RUNNER_TEMP/umbraco-cms"
+          npm --prefix "$RUNNER_TEMP/umbraco-cms/src/Umbraco.Web.UI.Client" ci
 
       - name: Install Playwright browsers
         run: npx --yes playwright install --with-deps chromium
@@ -86,6 +89,18 @@ jobs:
       - name: Build Umbraco host
         run: dotnet build Umbraco-CMS.Skills/Umbraco-CMS.Skills.csproj -c Debug
 
+      # Diagnostic: did the tree-example extension actually build into the host's served assets?
+      # If umbraco-package.json is present and the extension appears in the host's static web
+      # assets manifest, the failure is runtime loading — not a missing/unserved frontend.
+      - name: Diagnostic — extension assets
+        run: |
+          echo "== built tree-example App_Plugins =="
+          find plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example -path '*App_Plugins*' | head -40
+          echo "== umbraco-package.json (tree-example) =="
+          find plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example -name umbraco-package.json -exec cat {} \; || true
+          echo "== host static web assets manifest mentions of UmbTreeClient / NotesWiki =="
+          find Umbraco-CMS.Skills/bin Umbraco-CMS.Skills/obj -name '*staticwebassets*.json' 2>/dev/null | while read f; do echo "--- $f"; grep -o 'App_Plugins/[A-Za-z]*' "$f" | sort -u; done
+
       - name: Run mocked + E2E suites
         working-directory: .claude/skills/umbraco-skill-test-runner/scripts
         env:
@@ -93,7 +108,7 @@ jobs:
           URL: https://localhost:44325
           UMBRACO_USER_LOGIN: admin@example.com
           UMBRACO_USER_PASSWORD: '1234567890'
-          UMBRACO_CLIENT_PATH: ${{ github.workspace }}/umbraco-cms/src/Umbraco.Web.UI.Client
+          UMBRACO_CLIENT_PATH: ${{ runner.temp }}/umbraco-cms/src/Umbraco.Web.UI.Client
           # CI headroom: Playwright suites retry twice under CI (60s/test), and notes-wiki has
           # 34 tests — the local 180s cap kills them mid-retry and hides the real result.
           E2E_TIMEOUT_MS: '900000'

--- a/.github/workflows/validate-full.yml
+++ b/.github/workflows/validate-full.yml
@@ -6,6 +6,11 @@ name: Validate Skills (full — mocked + E2E)
 # run-tests.ts directly, which auto-starts and stops the Umbraco-CMS.Skills host.
 
 on:
+  # TEMPORARY: pull_request trigger so this heavy workflow can be verified on PR #92 before
+  # merge. schedule/workflow_dispatch only fire once the workflow is on the default branch,
+  # so this is the only way to test it pre-merge. REMOVE this block before merging.
+  pull_request:
+    branches: [dev]
   schedule:
     - cron: '0 3 * * *' # 03:00 UTC nightly
   workflow_dispatch:

--- a/.github/workflows/validate-full.yml
+++ b/.github/workflows/validate-full.yml
@@ -6,11 +6,6 @@ name: Validate Skills (full — mocked + E2E)
 # run-tests.ts directly, which auto-starts and stops the Umbraco-CMS.Skills host.
 
 on:
-  # TEMPORARY: pull_request trigger so this heavy workflow can be verified on PR #92 before
-  # merge. schedule/workflow_dispatch only fire once the workflow is on the default branch,
-  # so this is the only way to test it pre-merge. REMOVE this block before merging.
-  pull_request:
-    branches: [dev]
   schedule:
     - cron: '0 3 * * *' # 03:00 UTC nightly
   workflow_dispatch:

--- a/.github/workflows/validate-full.yml
+++ b/.github/workflows/validate-full.yml
@@ -74,19 +74,29 @@ jobs:
         working-directory: .claude/skills/umbraco-skill-test-runner/scripts
         run: npm install --no-audit --no-fund
 
-      # Build every example client FRESH. The examples split two ways: tree-example and
-      # notes-wiki gitignore their built wwwroot/App_Plugins (so skipping the build leaves
-      # their extensions absent — their E2E then can't find any UI); Blueprint and TimeDashboard
-      # commit theirs (so rebuilding drifts the vite content-hashes away from the committed
-      # static-asset references and breaks the .NET build). Deleting all committed App_Plugins
-      # first lets every client rebuild into a clean dir — no stale references, real frontends.
-      - name: Clean committed client assets
-        run: rm -rf plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/*/wwwroot/App_Plugins
+      # tree-example and notes-wiki gitignore their built wwwroot/App_Plugins, so a fresh
+      # checkout has no frontend for them and their E2E can't find any UI. Build those two
+      # clients explicitly BEFORE the host build so their assets exist in wwwroot when the
+      # .NET static-web-asset composition globs it. (Blueprint/TimeDashboard commit their
+      # assets, so they're already present.) Rebuilding must NOT happen inside the .NET build
+      # itself (SkipClientBuild below) — that drifts the committed examples' vite hashes and
+      # breaks their static-asset references.
+      - name: Build gitignored example clients
+        run: |
+          for d in tree-example notes-wiki; do
+            dir="plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/$d/Client"
+            echo "== building $dir =="
+            npm --prefix "$dir" ci
+            npm --prefix "$dir" run build
+          done
 
       # Pre-build the host so `dotnet run` (started by run-tests) boots within its 120s startup
-      # timeout — a cold NuGet restore + build of the example projects can exceed it otherwise.
-      # This runs each example's BuildClient target (npm i + vite) into the cleaned dirs.
+      # timeout — a cold NuGet restore + build can exceed it otherwise. SkipClientBuild makes the
+      # .NET build serve the assets already in wwwroot (committed + the two just built above)
+      # verbatim, without re-running vite (which would drift the committed examples' hashes).
       - name: Build Umbraco host
+        env:
+          SkipClientBuild: 'true'
         run: dotnet build Umbraco-CMS.Skills/Umbraco-CMS.Skills.csproj -c Debug
 
       # Diagnostic: did the tree-example extension actually build into the host's served assets?
@@ -109,6 +119,8 @@ jobs:
           UMBRACO_USER_LOGIN: admin@example.com
           UMBRACO_USER_PASSWORD: '1234567890'
           UMBRACO_CLIENT_PATH: ${{ runner.temp }}/umbraco-cms/src/Umbraco.Web.UI.Client
+          # Serve the assets built above verbatim; don't let `dotnet run` re-run vite.
+          SkipClientBuild: 'true'
           # CI headroom: Playwright suites retry twice under CI (60s/test), and notes-wiki has
           # 34 tests — the local 180s cap kills them mid-retry and hides the real result.
           E2E_TIMEOUT_MS: '900000'

--- a/.github/workflows/validate-full.yml
+++ b/.github/workflows/validate-full.yml
@@ -71,11 +71,19 @@ jobs:
         working-directory: .claude/skills/umbraco-skill-test-runner/scripts
         run: npm install --no-audit --no-fund
 
+      # Build every example client FRESH. The examples split two ways: tree-example and
+      # notes-wiki gitignore their built wwwroot/App_Plugins (so skipping the build leaves
+      # their extensions absent — their E2E then can't find any UI); Blueprint and TimeDashboard
+      # commit theirs (so rebuilding drifts the vite content-hashes away from the committed
+      # static-asset references and breaks the .NET build). Deleting all committed App_Plugins
+      # first lets every client rebuild into a clean dir — no stale references, real frontends.
+      - name: Clean committed client assets
+        run: rm -rf plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/*/wwwroot/App_Plugins
+
       # Pre-build the host so `dotnet run` (started by run-tests) boots within its 120s startup
       # timeout — a cold NuGet restore + build of the example projects can exceed it otherwise.
+      # This runs each example's BuildClient target (npm i + vite) into the cleaned dirs.
       - name: Build Umbraco host
-        env:
-          SkipClientBuild: 'true'
         run: dotnet build Umbraco-CMS.Skills/Umbraco-CMS.Skills.csproj -c Debug
 
       - name: Run mocked + E2E suites
@@ -86,11 +94,6 @@ jobs:
           UMBRACO_USER_LOGIN: admin@example.com
           UMBRACO_USER_PASSWORD: '1234567890'
           UMBRACO_CLIENT_PATH: ${{ github.workspace }}/umbraco-cms/src/Umbraco.Web.UI.Client
-          # MSBuild reads env vars as properties: skip the per-example vite rebuild during the
-          # E2E host build and serve the committed wwwroot/App_Plugins assets verbatim. Avoids
-          # non-deterministic content-hash drift (unpinned npm i) that broke the static-asset
-          # references on a fresh checkout.
-          SkipClientBuild: 'true'
           # CI headroom: Playwright suites retry twice under CI (60s/test), and notes-wiki has
           # 34 tests — the local 180s cap kills them mid-retry and hides the real result.
           E2E_TIMEOUT_MS: '900000'

--- a/.github/workflows/validate-full.yml
+++ b/.github/workflows/validate-full.yml
@@ -71,6 +71,13 @@ jobs:
         working-directory: .claude/skills/umbraco-skill-test-runner/scripts
         run: npm install --no-audit --no-fund
 
+      # Pre-build the host so `dotnet run` (started by run-tests) boots within its 120s startup
+      # timeout — a cold NuGet restore + build of the example projects can exceed it otherwise.
+      - name: Build Umbraco host
+        env:
+          SkipClientBuild: 'true'
+        run: dotnet build Umbraco-CMS.Skills/Umbraco-CMS.Skills.csproj -c Debug
+
       - name: Run mocked + E2E suites
         working-directory: .claude/skills/umbraco-skill-test-runner/scripts
         env:
@@ -79,6 +86,11 @@ jobs:
           UMBRACO_USER_LOGIN: admin@example.com
           UMBRACO_USER_PASSWORD: '1234567890'
           UMBRACO_CLIENT_PATH: ${{ github.workspace }}/umbraco-cms/src/Umbraco.Web.UI.Client
+          # MSBuild reads env vars as properties: skip the per-example vite rebuild during the
+          # E2E host build and serve the committed wwwroot/App_Plugins assets verbatim. Avoids
+          # non-deterministic content-hash drift (unpinned npm i) that broke the static-asset
+          # references on a fresh checkout.
+          SkipClientBuild: 'true'
         run: npx tsx run-tests.ts
 
       - name: Upload report

--- a/.github/workflows/validate-full.yml
+++ b/.github/workflows/validate-full.yml
@@ -91,7 +91,25 @@ jobs:
           # non-deterministic content-hash drift (unpinned npm i) that broke the static-asset
           # references on a fresh checkout.
           SkipClientBuild: 'true'
+          # CI headroom: Playwright suites retry twice under CI (60s/test), and notes-wiki has
+          # 34 tests — the local 180s cap kills them mid-retry and hides the real result.
+          E2E_TIMEOUT_MS: '900000'
+          MOCKED_TIMEOUT_MS: '300000'
         run: npx tsx run-tests.ts
+
+      # run-tests.ts is report-only (exits 0 even when suites fail), so gate on the report here.
+      - name: Enforce test results
+        if: always()
+        run: |
+          node -e '
+            const r = require("./test-report.json");
+            const { total, passed, failed, skipped } = r.summary;
+            console.log(`suites: total=${total} passed=${passed} failed=${failed} skipped=${skipped}`);
+            for (const x of r.results) console.log(`  ${x.status.padEnd(7)} ${x.type} ${x.example}`);
+            if ((r.orphans||[]).length) { console.error("orphan tests present"); process.exit(1); }
+            if (failed > 0 || skipped > 0) { console.error("FAIL: some suites failed or were skipped"); process.exit(1); }
+            console.log("all suites passed");
+          '
 
       - name: Upload report
         if: always()

--- a/.github/workflows/validate-full.yml
+++ b/.github/workflows/validate-full.yml
@@ -1,0 +1,85 @@
+name: Validate Skills (full — mocked + E2E)
+
+# The heavy half of /validate-skills: the mocked-backoffice and E2E suites. These need an
+# external v18 Umbraco.Web.UI.Client checkout (mocked) and the real .NET host (E2E), so they
+# run nightly and on demand rather than on every PR. Still no Claude / no tokens — this drives
+# run-tests.ts directly, which auto-starts and stops the Umbraco-CMS.Skills host.
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # 03:00 UTC nightly
+  workflow_dispatch:
+    inputs:
+      client_ref:
+        description: 'umbraco/Umbraco-CMS ref to build the client from'
+        default: 'release-18.0.1'
+        required: false
+
+concurrency:
+  group: validate-full
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Stock v18 client tag. The mocked harness patches a stock client and reverts, so no CMS
+  # branch is required — bump this when the repo targets a new v18 patch.
+  CLIENT_REF: ${{ github.event.inputs.client_ref || 'release-18.0.1' }}
+
+jobs:
+  full:
+    name: Mocked + E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout skills repo
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # --- Build the external v18 client (needed by the mocked-backoffice suites) ---
+      - name: Checkout Umbraco-CMS client
+        uses: actions/checkout@v4
+        with:
+          repository: umbraco/Umbraco-CMS
+          ref: ${{ env.CLIENT_REF }}
+          path: umbraco-cms
+
+      - name: Install client deps
+        working-directory: umbraco-cms/src/Umbraco.Web.UI.Client
+        # npm ci to match the lockfile exactly — an out-of-sync client renders a blank
+        # mocked page (uui-css -> static-copy -> msw 404). See repo notes.
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx --yes playwright install --with-deps chromium
+
+      - name: Install test-runner deps
+        working-directory: .claude/skills/umbraco-skill-test-runner/scripts
+        run: npm install --no-audit --no-fund
+
+      - name: Run mocked + E2E suites
+        working-directory: .claude/skills/umbraco-skill-test-runner/scripts
+        env:
+          SUITE_TYPES: mocked,e2e
+          URL: https://localhost:44325
+          UMBRACO_USER_LOGIN: admin@example.com
+          UMBRACO_USER_PASSWORD: '1234567890'
+          UMBRACO_CLIENT_PATH: ${{ github.workspace }}/umbraco-cms/src/Umbraco.Web.UI.Client
+        run: npx tsx run-tests.ts
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-full
+          path: test-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -94,3 +94,17 @@ jobs:
           name: test-report-unit
           path: test-report.json
           if-no-files-found: ignore
+      # run-tests.ts is report-only (exits 0 even when suites fail), so gate on the report here
+      # or a failing unit suite would silently pass the job.
+      - name: Enforce test results
+        if: always()
+        run: |
+          node -e '
+            const r = require("./test-report.json");
+            const { total, passed, failed, skipped } = r.summary;
+            console.log(`unit suites: total=${total} passed=${passed} failed=${failed} skipped=${skipped}`);
+            for (const x of r.results) console.log(`  ${x.status.padEnd(7)} ${x.path}`);
+            if ((r.orphans||[]).length) { console.error("orphan tests present"); process.exit(1); }
+            if (failed > 0 || skipped > 0) { console.error("FAIL: some unit suites failed or were skipped"); process.exit(1); }
+            console.log("all unit suites passed");
+          '

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,96 @@
+name: Validate Skills
+
+# Fast, always-on gate. Runs the same deterministic scripts that /validate-skills drives,
+# but directly (no Claude, no tokens) so it can block merges cheaply. The heavy mocked +
+# E2E suites (external v18 client checkout + .NET host) run separately — see validate-full.yml.
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    name: Link validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install validator deps
+        working-directory: .claude/skills/umbraco-skill-validator/scripts
+        run: npm install --no-audit --no-fund
+      - name: Validate links & references
+        working-directory: .claude/skills/umbraco-skill-validator/scripts
+        # GITHUB_TOKEN lifts the GitHub contents-API rate limit (60 -> 5000/hr).
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npx tsx validate-links.ts
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-report
+          path: validation-report.json
+          if-no-files-found: ignore
+
+  code:
+    name: Code analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install analyzer deps
+        working-directory: .claude/skills/umbraco-skill-code-analyzer/scripts
+        run: npm install --no-audit --no-fund
+      - name: Analyze code examples
+        working-directory: .claude/skills/umbraco-skill-code-analyzer/scripts
+        # Set CHECK_TYPESCRIPT=true here for full tsc compilation (slower).
+        run: npx tsx analyze-code.ts
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-analysis-report
+          path: code-analysis-report.json
+          if-no-files-found: ignore
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install test-runner deps
+        working-directory: .claude/skills/umbraco-skill-test-runner/scripts
+        run: npm install --no-audit --no-fund
+      - name: Install Playwright chromium
+        run: npx --yes playwright install --with-deps chromium
+      - name: Run unit suites
+        working-directory: .claude/skills/umbraco-skill-test-runner/scripts
+        # SUITE_TYPES=unit skips the mocked/E2E suites, which need an external client
+        # checkout and the .NET host (those run in validate-full.yml).
+        env:
+          SUITE_TYPES: unit
+        run: npx tsx run-tests.ts
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-unit
+          path: test-report.json
+          if-no-files-found: ignore

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/Blueprint/Blueprint.csproj
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/Blueprint/Blueprint.csproj
@@ -35,12 +35,12 @@
   </ItemGroup>
 
   <!-- Restore and build Client files -->
-  <Target Name="RestoreClient" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
+  <Target Name="RestoreClient" Condition="'$(SkipClientBuild)' != 'true'" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
     <Message Importance="high" Text="Restoring Client NPM packages..." />
     <Exec Command="npm i" WorkingDirectory="Client" />
   </Target>
 
-  <Target Name="BuildClient" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
+  <Target Name="BuildClient" Condition="'$(SkipClientBuild)' != 'true'" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
     <Message Importance="high" Text="Executing Client NPM build script..." />
     <Exec Command="npm run build" WorkingDirectory="Client" />
     <ItemGroup>

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/TimeDashboard/TimeDashboard.csproj
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/TimeDashboard/TimeDashboard.csproj
@@ -34,12 +34,12 @@
   </ItemGroup>
 
   <!-- Restore and build Client files -->
-  <Target Name="RestoreClient" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
+  <Target Name="RestoreClient" Condition="'$(SkipClientBuild)' != 'true'" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
     <Message Importance="high" Text="Restoring Client NPM packages..." />
     <Exec Command="npm i" WorkingDirectory="Client" />
   </Target>
 
-  <Target Name="BuildClient" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
+  <Target Name="BuildClient" Condition="'$(SkipClientBuild)' != 'true'" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
     <Message Importance="high" Text="Executing Client NPM build script..." />
     <Exec Command="npm run build" WorkingDirectory="Client" />
     <ItemGroup>

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/notes-wiki/NotesWiki.csproj
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/notes-wiki/NotesWiki.csproj
@@ -36,12 +36,12 @@
 
   <!-- Restore and build Client files (uncomment for automated builds) -->
   <!--
-  <Target Name="RestoreClient" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
+  <Target Name="RestoreClient" Condition="'$(SkipClientBuild)' != 'true'" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
     <Message Importance="high" Text="Restoring Client NPM packages..." />
     <Exec Command="npm i" WorkingDirectory="Client" />
   </Target>
 
-  <Target Name="BuildClient" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
+  <Target Name="BuildClient" Condition="'$(SkipClientBuild)' != 'true'" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
     <Message Importance="high" Text="Executing Client NPM build script..." />
     <Exec Command="npm run build" WorkingDirectory="Client" />
     <ItemGroup>

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example/UmbTreeClient.csproj
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example/UmbTreeClient.csproj
@@ -36,12 +36,12 @@
 
   <!-- Restore and build Client files -->
 	<!-- 
-  <Target Name="RestoreClient" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
+  <Target Name="RestoreClient" Condition="'$(SkipClientBuild)' != 'true'" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
     <Message Importance="high" Text="Restoring Client NPM packages..." />
     <Exec Command="npm i" WorkingDirectory="Client" />
   </Target>
 
-  <Target Name="BuildClient" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
+  <Target Name="BuildClient" Condition="'$(SkipClientBuild)' != 'true'" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
     <Message Importance="high" Text="Executing Client NPM build script..." />
     <Exec Command="npm run build" WorkingDirectory="Client" />
     <ItemGroup>


### PR DESCRIPTION
Adds CI that runs the same deterministic scripts \`/validate-skills\` drives — directly, with no Claude in the loop (zero token cost).

## Workflows
- **validate.yml** — fast gate on PRs to \`dev\`/\`main\` and pushes to \`dev\`. Three parallel jobs: link validation, code analysis, unit tests. No external checkout or .NET host needed.
- **validate-full.yml** — nightly (03:00 UTC) + manual \`workflow_dispatch\`. Mocked + E2E suites against a stock \`umbraco/Umbraco-CMS@release-18.0.1\` client and the auto-started .NET 10 host.

## Script tweaks (both backward-compatible)
- \`run-tests.ts\`: \`SUITE_TYPES\` env allow-list (default: all) so CI can run a unit-only gate.
- \`validate-links.ts\`: authenticates GitHub contents-API calls with \`GITHUB_TOKEN\` to dodge the 60 req/hr limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)