### PR TITLE
chore(release): 18.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Umbraco backoffice customization skills for Claude Code",
-    "version": "18.0.1",
+    "version": "18.0.2",
     "homepage": "https://github.com/hifi-phil/UmbracoCMS_Skills"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umbraco-cms-backoffice-skills",
       "source": "./plugins/umbraco-backoffice-skills",
       "description": "Umbraco backoffice skills covering Foundation, Extension Types, Property Editors, Rich Text, Backend, and Setup",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",

--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",


### PR DESCRIPTION
Release **18.0.2** (v18 line).

Bumps **umbraco-cms-backoffice-skills** 18.0.1 → 18.0.2 (plugin.json + marketplace entry) and marketplace `metadata.version` → 18.0.2. **umbraco-cms-backoffice-testing-skills** is unchanged since v18.0.1 and stays at 18.0.1.

### Changed since v18.0.1 (under `plugins/umbraco-backoffice-skills/`)
- #90 — feat: version-guard preflight to prevent v17/v18 skill confusion
- #92 — ci: GitHub Actions skill validation (example `.csproj` SkipClientBuild opt-in)

After merge: promote `dev` → `main` (merge commit), tag `v18.0.2`, and cut the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)