### PR TITLE
Release 18.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Umbraco backoffice customization skills for Claude Code",
-    "version": "18.0.1",
+    "version": "18.0.2",
     "homepage": "https://github.com/hifi-phil/UmbracoCMS_Skills"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umbraco-cms-backoffice-skills",
       "source": "./plugins/umbraco-backoffice-skills",
       "description": "Umbraco backoffice skills covering Foundation, Extension Types, Property Editors, Rich Text, Backend, and Setup",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",

--- a/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
+++ b/.claude/skills/umbraco-skill-test-runner/scripts/run-tests.ts
@@ -64,10 +64,44 @@ interface TestableExample {
 let UMBRACO_URL = process.env.UMBRACO_URL || 'https://localhost:44325';
 const UMBRACO_URL_EXPLICIT = !!process.env.UMBRACO_URL;
 const UMBRACO_PROJECT_PATH = join(PROJECT_ROOT, 'Umbraco-CMS.Skills');
-const TEST_TIMEOUT_UNIT = 60000;
-const TEST_TIMEOUT_MOCKED = 120000;
-const TEST_TIMEOUT_E2E = 180000;
+// SUITE_TYPES: optional comma-separated allow-list of suite types to run (e.g. "unit"
+// or "unit,mocked"). Defaults to all three. Lets CI run a cheap unit-only gate on every
+// PR without pulling in the mocked/E2E prerequisites (external client checkout, .NET host).
+const SUITE_TYPES: Set<TestType> = new Set(
+  (process.env.SUITE_TYPES ?? 'unit,mocked,e2e')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean) as TestType[]
+);
+// Per-suite wall-clock caps (safety net around each spawned test process). Overridable via
+// env because CI needs more headroom: Playwright suites set `retries: CI ? 2 : 0`, so a single
+// slow/flaky test can take timeout×3, and large suites (e.g. notes-wiki's 34 tests) legitimately
+// run longer than the local defaults. Too low a cap kills the suite mid-retry and masks the real
+// pass/fail as a generic "Test timed out".
+const TEST_TIMEOUT_UNIT = Number(process.env.UNIT_TIMEOUT_MS) || 60000;
+const TEST_TIMEOUT_MOCKED = Number(process.env.MOCKED_TIMEOUT_MS) || 120000;
+const TEST_TIMEOUT_E2E = Number(process.env.E2E_TIMEOUT_MS) || 180000;
 const UMBRACO_STARTUP_TIMEOUT = 120000;
+
+// Glob ignores shared by discovery and the orphan audit. Besides the usual build dirs, we
+// must exclude the external Umbraco client checkout (UMBRACO_CLIENT_PATH) when it lands
+// INSIDE the repo tree — as it does in CI, where actions/checkout can only clone into the
+// workspace. That client ships its own examples/**/*.test.ts which would otherwise be
+// discovered as suites and flagged as orphans, failing the run with exit 2.
+function externalIgnoreGlobs(): string[] {
+  const ignores: string[] = [];
+  const clientPath = process.env.UMBRACO_CLIENT_PATH;
+  if (clientPath) {
+    const rel = relative(PROJECT_ROOT, resolve(clientPath));
+    // Only ignore when the client is under PROJECT_ROOT (rel doesn't escape upward).
+    if (rel && !rel.startsWith('..')) {
+      const top = rel.split('/')[0];
+      ignores.push(`${top}/**`);
+    }
+  }
+  return ignores;
+}
+const BASE_IGNORES = ['**/node_modules/**', '**/dist/**'];
 
 // Track Umbraco process if we start it
 let umbracoProcess: ChildProcess | null = null;
@@ -79,7 +113,7 @@ let weStartedUmbraco = false;
 async function discoverTestableExamples(): Promise<TestableExample[]> {
   const packageFiles = await glob('**/examples/**/package.json', {
     cwd: PROJECT_ROOT,
-    ignore: ['**/node_modules/**', '**/dist/**']
+    ignore: [...BASE_IGNORES, ...externalIgnoreGlobs()]
   });
 
   const examples: TestableExample[] = [];
@@ -309,6 +343,17 @@ async function runTest(
   const startTime = Date.now();
   const exampleDir = join(PROJECT_ROOT, example.path);
 
+  // Every suite here launches a browser via the example's OWN pinned Playwright — mocked/e2e via
+  // @playwright/test, unit via @web/test-runner-playwright — and those versions differ across
+  // examples (1.49 / 1.56 / 1.57 …), each needing a different browser build. A single top-level
+  // `playwright install` can't satisfy them all, so install the right browser from within the
+  // example here (idempotent; fast when already cached).
+  try {
+    execSync('npx playwright install chromium', { cwd: exampleDir, stdio: 'ignore' });
+  } catch {
+    console.error(`  Warning: playwright browser install failed in ${example.path} — suite may fail to launch`);
+  }
+
   // Determine timeout
   const timeout = test.type === 'unit' ? TEST_TIMEOUT_UNIT :
                   test.type === 'mocked' ? TEST_TIMEOUT_MOCKED : TEST_TIMEOUT_E2E;
@@ -420,7 +465,7 @@ async function auditTestCoverage(examples: TestableExample[]): Promise<OrphanTes
   // 2) Every spec/test file under examples/ should belong to an example that has a suite.
   const specFiles = await glob('**/examples/**/*.{spec,test}.ts', {
     cwd: PROJECT_ROOT,
-    ignore: ['**/node_modules/**', '**/dist/**', '**/test-results/**', '**/playwright-report/**']
+    ignore: [...BASE_IGNORES, '**/test-results/**', '**/playwright-report/**', ...externalIgnoreGlobs()]
   });
   const testableDirs = examples.filter(e => e.tests.length > 0).map(e => e.path);
   for (const spec of specFiles) {
@@ -474,6 +519,7 @@ async function runTests(): Promise<TestReport> {
 
   for (const example of examples) {
     for (const test of example.tests) {
+      if (!SUITE_TYPES.has(test.type)) continue; // SUITE_TYPES allow-list (default: all)
       if (test.type === 'unit') {
         unitTests.push({ example, test });
       } else if (test.type === 'mocked') {
@@ -482,6 +528,9 @@ async function runTests(): Promise<TestReport> {
         e2eTests.push({ example, test });
       }
     }
+  }
+  if (SUITE_TYPES.size < 3) {
+    console.error(`Suite filter active (SUITE_TYPES): running only ${[...SUITE_TYPES].join(', ')}`);
   }
 
   // Run unit tests first

--- a/.claude/skills/umbraco-skill-validator/scripts/validate-links.ts
+++ b/.claude/skills/umbraco-skill-validator/scripts/validate-links.ts
@@ -2,7 +2,7 @@
 
 import { readFileSync, existsSync, writeFileSync } from 'fs';
 import { glob } from 'glob';
-import { dirname, resolve, join } from 'path';
+import { dirname, resolve, join, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { retry, handleAll, ExponentialBackoff } from 'cockatiel';
 
@@ -65,6 +65,7 @@ const SKIP_URL_PATTERNS = [
   /^https?:\/\/example\.com/,
   /^https?:\/\/my-docs\.com/,  // Example placeholder
   /^http:\/\/www\.w3\.org/,     // XML namespaces
+  /[{}]/,                        // Template placeholders, e.g. {SITE_MAJOR} — not real URLs
 ];
 
 // Find all SKILL.md files
@@ -75,6 +76,17 @@ async function discoverSkills(basePath: string): Promise<string[]> {
     ignore: ['**/node_modules/**', '**/dist/**']
   });
   return files.map(f => join(basePath, f));
+}
+
+// Find all agent names (agents live as `<name>.md` under a plugin `agents/` dir). Agents are
+// referenced from SKILL.md like skills (e.g. `umbraco-extension-reviewer`) but aren't skills,
+// so they must join the known-names set or they'd be flagged as missing skills.
+async function discoverAgentNames(basePath: string): Promise<string[]> {
+  const files = await glob('**/agents/*.md', {
+    cwd: basePath,
+    ignore: ['**/node_modules/**', '**/dist/**']
+  });
+  return files.map(f => basename(f, '.md')).filter(Boolean);
 }
 
 // Extract links from content with line numbers
@@ -202,10 +214,14 @@ async function checkUmbracoPath(path: string): Promise<boolean> {
   // Fall back to GitHub API
   try {
     const apiPath = path.replace('/Umbraco-CMS/', '').replace(/^\//, '');
+    // Authenticate when a token is present (GITHUB_TOKEN is provided automatically in
+    // GitHub Actions). Raises the rate limit from 60 to 5000 req/hr so CI doesn't flake.
+    const ghToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
     const response = await fetch(`${GITHUB_API_BASE}/${apiPath}`, {
       headers: {
         'Accept': 'application/vnd.github.v3+json',
-        'User-Agent': 'skill-validator'
+        'User-Agent': 'skill-validator',
+        ...(ghToken ? { Authorization: `Bearer ${ghToken}` } : {})
       }
     });
     return response.status === 200;
@@ -329,11 +345,14 @@ async function validate(): Promise<ValidationReport> {
   const skillPaths = await discoverSkills(basePath);
   console.error(`Found ${skillPaths.length} SKILL.md files`);
 
-  // Extract all skill names for reference checking
-  const allSkillNames = skillPaths.map(p => {
+  // Extract all skill names for reference checking, plus agent names (referenced the same
+  // way in SKILL.md but not skills themselves — e.g. umbraco-extension-reviewer).
+  const skillNames = skillPaths.map(p => {
     const dir = dirname(p);
     return dir.split('/').pop() || '';
   }).filter(Boolean);
+  const agentNames = await discoverAgentNames(basePath);
+  const allSkillNames = [...skillNames, ...agentNames];
 
   const stats: ValidationReport['statistics'] = {
     urlsChecked: 0,

--- a/.github/workflows/validate-full.yml
+++ b/.github/workflows/validate-full.yml
@@ -1,0 +1,145 @@
+name: Validate Skills (full — mocked + E2E)
+
+# The heavy half of /validate-skills: the mocked-backoffice and E2E suites. These need an
+# external v18 Umbraco.Web.UI.Client checkout (mocked) and the real .NET host (E2E), so they
+# run nightly and on demand rather than on every PR. Still no Claude / no tokens — this drives
+# run-tests.ts directly, which auto-starts and stops the Umbraco-CMS.Skills host.
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # 03:00 UTC nightly
+  workflow_dispatch:
+    inputs:
+      client_ref:
+        description: 'umbraco/Umbraco-CMS ref to build the client from'
+        default: 'release-18.0.1'
+        required: false
+
+concurrency:
+  group: validate-full
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Stock v18 client tag. The mocked harness patches a stock client and reverts, so no CMS
+  # branch is required — bump this when the repo targets a new v18 patch.
+  CLIENT_REF: ${{ github.event.inputs.client_ref || 'release-18.0.1' }}
+
+jobs:
+  full:
+    name: Mocked + E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout skills repo
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # --- Umbraco source (v18 client) needed by the mocked-backoffice suites. Cloned BESIDE the
+      # repo (under RUNNER_TEMP, outside GITHUB_WORKSPACE) and cached across runs, so nightly runs
+      # skip the slow clone + npm ci. Keeping it out of the workspace also keeps its own
+      # examples/**/*.test.ts out of the test runner's discovery/orphan audit.
+      - name: Cache Umbraco source
+        id: cache-umbraco
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/umbraco-cms
+          key: umbraco-src-${{ env.CLIENT_REF }}-v1
+
+      - name: Clone & install Umbraco client (cache miss)
+        if: steps.cache-umbraco.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "$CLIENT_REF" https://github.com/umbraco/Umbraco-CMS "$RUNNER_TEMP/umbraco-cms"
+          npm --prefix "$RUNNER_TEMP/umbraco-cms/src/Umbraco.Web.UI.Client" ci
+
+      - name: Install Playwright browsers
+        run: npx --yes playwright install --with-deps chromium
+
+      - name: Install test-runner deps
+        working-directory: .claude/skills/umbraco-skill-test-runner/scripts
+        run: npm install --no-audit --no-fund
+
+      # tree-example and notes-wiki gitignore their built wwwroot/App_Plugins, so a fresh
+      # checkout has no frontend for them and their E2E can't find any UI. Build those two
+      # clients explicitly BEFORE the host build so their assets exist in wwwroot when the
+      # .NET static-web-asset composition globs it. (Blueprint/TimeDashboard commit their
+      # assets, so they're already present.) Rebuilding must NOT happen inside the .NET build
+      # itself (SkipClientBuild below) — that drifts the committed examples' vite hashes and
+      # breaks their static-asset references.
+      - name: Build gitignored example clients
+        run: |
+          for d in tree-example notes-wiki; do
+            dir="plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/$d/Client"
+            echo "== building $dir =="
+            npm --prefix "$dir" ci
+            npm --prefix "$dir" run build
+          done
+
+      # Pre-build the host so `dotnet run` (started by run-tests) boots within its 120s startup
+      # timeout — a cold NuGet restore + build can exceed it otherwise. SkipClientBuild makes the
+      # .NET build serve the assets already in wwwroot (committed + the two just built above)
+      # verbatim, without re-running vite (which would drift the committed examples' hashes).
+      - name: Build Umbraco host
+        env:
+          SkipClientBuild: 'true'
+        run: dotnet build Umbraco-CMS.Skills/Umbraco-CMS.Skills.csproj -c Debug
+
+      # Diagnostic: did the tree-example extension actually build into the host's served assets?
+      # If umbraco-package.json is present and the extension appears in the host's static web
+      # assets manifest, the failure is runtime loading — not a missing/unserved frontend.
+      - name: Diagnostic — extension assets
+        run: |
+          echo "== built tree-example App_Plugins =="
+          find plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example -path '*App_Plugins*' | head -40
+          echo "== umbraco-package.json (tree-example) =="
+          find plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example -name umbraco-package.json -exec cat {} \; || true
+          echo "== host static web assets manifest mentions of UmbTreeClient / NotesWiki =="
+          find Umbraco-CMS.Skills/bin Umbraco-CMS.Skills/obj -name '*staticwebassets*.json' 2>/dev/null | while read f; do echo "--- $f"; grep -o 'App_Plugins/[A-Za-z]*' "$f" | sort -u; done
+
+      - name: Run mocked + E2E suites
+        working-directory: .claude/skills/umbraco-skill-test-runner/scripts
+        env:
+          SUITE_TYPES: mocked,e2e
+          URL: https://localhost:44325
+          UMBRACO_USER_LOGIN: admin@example.com
+          UMBRACO_USER_PASSWORD: '1234567890'
+          UMBRACO_CLIENT_PATH: ${{ runner.temp }}/umbraco-cms/src/Umbraco.Web.UI.Client
+          # Serve the assets built above verbatim; don't let `dotnet run` re-run vite.
+          SkipClientBuild: 'true'
+          # CI headroom: Playwright suites retry twice under CI (60s/test), and notes-wiki has
+          # 34 tests — the local 180s cap kills them mid-retry and hides the real result.
+          E2E_TIMEOUT_MS: '900000'
+          MOCKED_TIMEOUT_MS: '300000'
+        run: npx tsx run-tests.ts
+
+      # run-tests.ts is report-only (exits 0 even when suites fail), so gate on the report here.
+      - name: Enforce test results
+        if: always()
+        run: |
+          node -e '
+            const r = require("./test-report.json");
+            const { total, passed, failed, skipped } = r.summary;
+            console.log(`suites: total=${total} passed=${passed} failed=${failed} skipped=${skipped}`);
+            for (const x of r.results) console.log(`  ${x.status.padEnd(7)} ${x.type} ${x.example}`);
+            if ((r.orphans||[]).length) { console.error("orphan tests present"); process.exit(1); }
+            if (failed > 0 || skipped > 0) { console.error("FAIL: some suites failed or were skipped"); process.exit(1); }
+            console.log("all suites passed");
+          '
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-full
+          path: test-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,110 @@
+name: Validate Skills
+
+# Fast, always-on gate. Runs the same deterministic scripts that /validate-skills drives,
+# but directly (no Claude, no tokens) so it can block merges cheaply. The heavy mocked +
+# E2E suites (external v18 client checkout + .NET host) run separately — see validate-full.yml.
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    name: Link validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install validator deps
+        working-directory: .claude/skills/umbraco-skill-validator/scripts
+        run: npm install --no-audit --no-fund
+      - name: Validate links & references
+        working-directory: .claude/skills/umbraco-skill-validator/scripts
+        # GITHUB_TOKEN lifts the GitHub contents-API rate limit (60 -> 5000/hr).
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npx tsx validate-links.ts
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-report
+          path: validation-report.json
+          if-no-files-found: ignore
+
+  code:
+    name: Code analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install analyzer deps
+        working-directory: .claude/skills/umbraco-skill-code-analyzer/scripts
+        run: npm install --no-audit --no-fund
+      - name: Analyze code examples
+        working-directory: .claude/skills/umbraco-skill-code-analyzer/scripts
+        # Set CHECK_TYPESCRIPT=true here for full tsc compilation (slower).
+        run: npx tsx analyze-code.ts
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-analysis-report
+          path: code-analysis-report.json
+          if-no-files-found: ignore
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install test-runner deps
+        working-directory: .claude/skills/umbraco-skill-test-runner/scripts
+        run: npm install --no-audit --no-fund
+      - name: Install Playwright chromium
+        run: npx --yes playwright install --with-deps chromium
+      - name: Run unit suites
+        working-directory: .claude/skills/umbraco-skill-test-runner/scripts
+        # SUITE_TYPES=unit skips the mocked/E2E suites, which need an external client
+        # checkout and the .NET host (those run in validate-full.yml).
+        env:
+          SUITE_TYPES: unit
+        run: npx tsx run-tests.ts
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-unit
+          path: test-report.json
+          if-no-files-found: ignore
+      # run-tests.ts is report-only (exits 0 even when suites fail), so gate on the report here
+      # or a failing unit suite would silently pass the job.
+      - name: Enforce test results
+        if: always()
+        run: |
+          node -e '
+            const r = require("./test-report.json");
+            const { total, passed, failed, skipped } = r.summary;
+            console.log(`unit suites: total=${total} passed=${passed} failed=${failed} skipped=${skipped}`);
+            for (const x of r.results) console.log(`  ${x.status.padEnd(7)} ${x.path}`);
+            if ((r.orphans||[]).length) { console.error("orphan tests present"); process.exit(1); }
+            if (failed > 0 || skipped > 0) { console.error("FAIL: some unit suites failed or were skipped"); process.exit(1); }
+            console.log("all unit suites passed");
+          '

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,16 +115,24 @@ The runner globs `**/examples/**/package.json` and maps script names to suite ty
 
 ## Releasing
 
-Releases are cut from a `release/<version>` branch and tagged `v<version>` once merged.
-The tag is the release marker — "what changed since the last release" is always
-`git diff <last tag>..HEAD`. **Bump only the plugins whose files changed since that tag.**
+**Branch model.** Each Umbraco major has an integration branch and a stable/released branch:
+
+| Major | Integration (feature PRs land here) | Stable (releases live here) |
+|---|---|---|
+| 18 (current) | `dev` | `main` |
+| 17 | `v17/dev` | `v17/main` |
+
+Feature PRs merge into the integration branch. A **release promotes the integration branch to
+its stable branch** and tags it `v<version>`. The tag is the release marker — "what changed since
+the last release" is always `git diff <last tag>..HEAD`. **Bump only the plugins whose files
+changed since that tag.**
 
 There are **three** version fields, and the two per-plugin ones must stay paired:
 - `.claude-plugin/marketplace.json` → `metadata.version` — the overall marketplace/release version.
 - `.claude-plugin/marketplace.json` → each `plugins[].version` — one per plugin.
 - `plugins/<plugin>/.claude-plugin/plugin.json` → `version` — must equal that plugin's marketplace entry.
 
-Steps:
+Steps (shown for the 18 line — for 17 substitute `v17/dev` / `v17/main`):
 
 1. **Find the last release** and confirm the target version:
    ```bash
@@ -144,7 +152,7 @@ Steps:
    A plugin **changed** if it has any commits/file changes under `plugins/<plugin>/` — including
    example code, lockfiles, and generated `wwwroot/App_Plugins/` assets, not just SKILL.md text.
 
-3. **Create the release branch** off `dev`:
+3. **Create the release branch** off the integration branch:
    ```bash
    git checkout dev && git pull
    git checkout -b release/<version>
@@ -157,10 +165,18 @@ Steps:
 5. **Validate** — run `/validate-skills` (full: links + code + all tests incl. E2E). A release
    is not ready while any suite fails or E2E is `skipped`.
 
-6. **PR → merge → tag.** Open the release PR against `dev`, merge, then tag the merge commit and push:
+6. **Land the bump on the integration branch.** PR `release/<version>` → `dev` and merge, so
+   `dev` carries the new version.
+
+7. **Promote to the stable branch.** PR `dev` → `main` and merge (use a **merge commit**, not
+   squash, so the exact released commit stays reachable on `main`). Direct pushes to `main` are
+   blocked — always go through the PR.
+
+8. **Tag the release on the stable branch** and create the GitHub release:
    ```bash
-   git tag -a v<version> -m "Release <version>" && git push origin v<version>
+   gh release create v<version> --target main --title "v<version> — Umbraco 18 line" --notes "…"
    ```
+   Mark the highest active major `--latest`; older lines (e.g. `v17.x`) use `--latest=false`.
    The tag is what the *next* release diffs against — don't skip it.
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Experimental Beta:** This project is an exploration of what's possible with Skills for Umbraco. It's evolving as we learn what works best.
 
-A Claude Code plugin marketplace with 66 skills for Umbraco backoffice customization and testing.
+A Claude Code plugin marketplace with 67 skills for Umbraco backoffice customization and testing.
 
 ## Quick Start
 
@@ -13,12 +13,46 @@ Add the marketplace:
 
 Install the plugins:
 ```bash
-# Backoffice extension skills (58 skills)
+# Backoffice extension skills (59 skills)
 /plugin install umbraco-cms-backoffice-skills@umbraco-backoffice-marketplace
 
 # Testing skills (8 skills) - optional but recommended
 /plugin install umbraco-cms-backoffice-testing-skills@umbraco-backoffice-marketplace
 ```
+
+---
+
+## ⚠️ Match the skills to your Umbraco major
+
+**These skills are versioned to a single Umbraco major** (tree data sources, auth, OpenAPI
+registration and more differ between majors, so loading the wrong line produces
+confidently-incorrect code). Each major gets its own line, following one rule:
+
+- **The default `main` branch always targets the latest supported major.**
+- **Older majors live on a `vN/main` branch** (e.g. `v17/main`).
+
+So pick your install by your site's major:
+
+| Your site is… | Install command |
+|---|---|
+| **The latest major** (whatever `main` currently targets) | `/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills` |
+| **An older major `N`** | `/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#vN/main` |
+
+> _Currently `main` targets Umbraco 18, and `v17/main` is available for Umbraco 17. When a
+> new major ships, `main` moves to it and the previous major moves to its own `vN/main`._
+
+For the **Vercel Skills CLI** (Cursor/Copilot/Windsurf), point the repo URL at the matching
+branch — `main` for the latest major, or `.../tree/vN/main/...` for an older one.
+
+**Not sure which major your site is?** Check the `Umbraco.Cms` version in your project's
+`.csproj`, or the `@umbraco-cms/backoffice` version in your `Client/package.json`.
+
+**Automatic safety net:** the `umbraco-version-guard` skill runs as a preflight inside the
+entry skills (`umbraco-quickstart`, `umbraco-backoffice`, `umbraco-extension-template`). It
+derives the major these skills target from the plugin itself, detects your site's major,
+and **stops with a warning if they don't match** — so a mismatch can't silently produce
+wrong code, and the check stays correct as new majors ship. Run it directly any time with
+`/umbraco-version-guard`.
 
 ---
 
@@ -42,7 +76,7 @@ npx skills add umbraco/Umbraco-CMS-Backoffice-Skills --skill '*' -a windsurf
 
 Or install each skill set separately:
 ```bash
-# Backoffice extension skills (58 skills)
+# Backoffice extension skills (59 skills)
 npx skills add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills/tree/main/plugins/umbraco-backoffice-skills/skills -a cursor
 
 # Testing skills (8 skills) - optional but recommended
@@ -64,7 +98,7 @@ npx skills add umbraco/Umbraco-CMS-Backoffice-Skills --skill umbraco-dashboard -
 | **Windsurf** | Current | `.windsurf/skills/` |
 | **Claude Code** | Current (use Quick Start above) | `.claude/skills/` |
 
-All of these editors load skills **on-demand** — only the skill relevant to your current task is loaded into context, so installing all 66 skills won't affect performance.
+All of these editors load skills **on-demand** — only the skill relevant to your current task is loaded into context, so installing all 67 skills won't affect performance.
 
 ---
 
@@ -354,7 +388,7 @@ Umbraco-CMS-Backoffice-Skills/
 │   │   └── skills/
 │   │       ├── umbraco-dashboard/SKILL.md
 │   │       ├── umbraco-tree/SKILL.md
-│   │       └── ... (57 skills)
+│   │       └── ... (58 skills)
 │   └── umbraco-testing-skills/         # Plugin with 8 testing skills
 │       ├── .claude-plugin/plugin.json
 │       └── skills/

--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/SKILL.md
@@ -27,6 +27,10 @@ For details on individual extension types, invoke the referenced sub-skills.
 
 **CRITICAL**: This workflow is MANDATORY for ALL extension development.
 
+**Step 0 — Version guard:** Before planning, invoke `umbraco-version-guard` to confirm
+the site's Umbraco major matches the major these skills target. Stop on a mismatch — the
+backoffice API differs between Umbraco majors and these skills will produce wrong code.
+
 ```
 1. PLAN ──► Read PRE-BUILD-PLANNING.md FIRST
    │        Draw wireframe, label extension types, identify UUI components

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/Blueprint/Blueprint.csproj
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/Blueprint/Blueprint.csproj
@@ -35,12 +35,12 @@
   </ItemGroup>
 
   <!-- Restore and build Client files -->
-  <Target Name="RestoreClient" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
+  <Target Name="RestoreClient" Condition="'$(SkipClientBuild)' != 'true'" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
     <Message Importance="high" Text="Restoring Client NPM packages..." />
     <Exec Command="npm i" WorkingDirectory="Client" />
   </Target>
 
-  <Target Name="BuildClient" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
+  <Target Name="BuildClient" Condition="'$(SkipClientBuild)' != 'true'" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
     <Message Importance="high" Text="Executing Client NPM build script..." />
     <Exec Command="npm run build" WorkingDirectory="Client" />
     <ItemGroup>

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/TimeDashboard/TimeDashboard.csproj
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/TimeDashboard/TimeDashboard.csproj
@@ -34,12 +34,12 @@
   </ItemGroup>
 
   <!-- Restore and build Client files -->
-  <Target Name="RestoreClient" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
+  <Target Name="RestoreClient" Condition="'$(SkipClientBuild)' != 'true'" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
     <Message Importance="high" Text="Restoring Client NPM packages..." />
     <Exec Command="npm i" WorkingDirectory="Client" />
   </Target>
 
-  <Target Name="BuildClient" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
+  <Target Name="BuildClient" Condition="'$(SkipClientBuild)' != 'true'" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
     <Message Importance="high" Text="Executing Client NPM build script..." />
     <Exec Command="npm run build" WorkingDirectory="Client" />
     <ItemGroup>

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/notes-wiki/NotesWiki.csproj
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/notes-wiki/NotesWiki.csproj
@@ -36,12 +36,12 @@
 
   <!-- Restore and build Client files (uncomment for automated builds) -->
   <!--
-  <Target Name="RestoreClient" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
+  <Target Name="RestoreClient" Condition="'$(SkipClientBuild)' != 'true'" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
     <Message Importance="high" Text="Restoring Client NPM packages..." />
     <Exec Command="npm i" WorkingDirectory="Client" />
   </Target>
 
-  <Target Name="BuildClient" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
+  <Target Name="BuildClient" Condition="'$(SkipClientBuild)' != 'true'" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
     <Message Importance="high" Text="Executing Client NPM build script..." />
     <Exec Command="npm run build" WorkingDirectory="Client" />
     <ItemGroup>

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example/UmbTreeClient.csproj
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-backoffice/examples/tree-example/UmbTreeClient.csproj
@@ -36,12 +36,12 @@
 
   <!-- Restore and build Client files -->
 	<!-- 
-  <Target Name="RestoreClient" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
+  <Target Name="RestoreClient" Condition="'$(SkipClientBuild)' != 'true'" Inputs="Client\package.json;Client\package-lock.json" Outputs="Client\node_modules\.package-lock.json">
     <Message Importance="high" Text="Restoring Client NPM packages..." />
     <Exec Command="npm i" WorkingDirectory="Client" />
   </Target>
 
-  <Target Name="BuildClient" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
+  <Target Name="BuildClient" Condition="'$(SkipClientBuild)' != 'true'" BeforeTargets="AssignTargetPaths" DependsOnTargets="RestoreClient" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)client.complete.txt">
     <Message Importance="high" Text="Executing Client NPM build script..." />
     <Exec Command="npm run build" WorkingDirectory="Client" />
     <ItemGroup>

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-extension-template/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-extension-template/SKILL.md
@@ -25,6 +25,8 @@ Always fetch the latest docs before implementing:
 
 ## Workflow
 
+0. **Version guard**: Invoke `umbraco-version-guard` first to confirm the target site's
+   Umbraco major matches the major these skills target. Stop on a mismatch.
 1. **Install template** (one-time): `dotnet new install Umbraco.Templates`
 2. **Create extension**: `dotnet new umbraco-extension -n MyExtension`
 3. **Install dependencies**: `cd MyExtension/Client && npm install`

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-quickstart/SKILL.md
@@ -40,6 +40,10 @@ If arguments not provided, check what exists and prompt for missing names.
 
 ### 2. Check what exists
 
+**Version guard (run first):** Before building anything, invoke `umbraco-version-guard`
+to confirm the site's Umbraco major matches the major these skills target. On a mismatch,
+stop and point the user at the matching skill line — do not generate code.
+
 **Check for Umbraco instance:**
 ```bash
 find . -name "*.csproj" -exec grep -l "Umbraco.Cms" {} \; 2>/dev/null | head -5

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-version-guard/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-version-guard/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: umbraco-version-guard
+description: Deterministically verify that the Umbraco major of the site you are working on matches the major these skills target. Run this FIRST, before any Umbraco backoffice work, to avoid mixing guidance across Umbraco majors (e.g. 17 vs 18 vs 19). Trigger on the first Umbraco task in a session, or whenever the site's version is uncertain.
+version: 1.0.0
+location: managed
+allowed-tools: Bash, Read, Grep, Glob, WebFetch
+user_invocable: true
+---
+
+# Umbraco Version Guard
+
+## What this skill does
+
+The Umbraco backoffice API changes between majors (tree data sources, auth, OpenAPI
+registration, and more). **These skills target one specific major.** Applying them to a
+site on a different major produces confidently-wrong code.
+
+This skill is a **preflight check**: it derives the target major from the plugin itself
+(so it never goes stale as new majors ship), detects the target site's major
+deterministically, compares them, and STOPS with the correct install command on a
+mismatch. Nothing here hardcodes a specific major number — both sides are computed.
+
+## Step 1 — Determine the major these skills target
+
+The plugin's own version is the source of truth, and it bumps every major at release. Read
+it and take the leading number:
+
+```bash
+# Primary: the installed plugin's version. First path is the Claude Code plugin layout;
+# the greps are fallbacks for when the skill was copied flat into an editor's skills dir.
+cat "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null \
+  || cat ../../.claude-plugin/plugin.json 2>/dev/null \
+  | grep -m1 '"version"' | grep -oE '[0-9]+' | head -1
+```
+
+Call this **TARGET_MAJOR**. If none of the paths resolve (a flat copy with no
+`plugin.json` alongside), fall back to the marketplace version, and only then to reading
+the value a sibling skill states — never invent a number. If you genuinely cannot
+determine it, say so and skip the guard rather than guessing.
+
+## Step 2 — Detect the site's Umbraco major (deterministic, no running instance needed)
+
+Try these signals in order and stop at the first that yields a number. Each extracts just
+the **major**, so it works with `18.0.0`, `18.*`, `[18.0.0,)`, or plain `18`.
+
+**A. `Umbraco.Cms` package reference (ground truth — what is actually installed).** Covers
+`*.csproj` PackageReference and central-package-management `*.props` (PackageVersion); the
+trailing `"` after `Cms` excludes `Umbraco.Cms.DevelopmentMode` etc.
+
+```bash
+grep -rhoE 'Umbraco\.Cms"[^0-9]*[0-9]+' --include='*.csproj' --include='*.props' . 2>/dev/null \
+  | grep -oE '[0-9]+$' | sort -u
+```
+
+**B. Fallback — the backoffice client dependency major** (handles `^18.0.0`, `~18.0.0`, `18.0.0`):
+
+```bash
+grep -rhoE '"@umbraco-cms/backoffice":[^0-9]*[0-9]+' --include='package.json' . 2>/dev/null \
+  | grep -oE '[0-9]+$' | sort -u
+```
+
+**C. Last resort — a running instance's Server Information API** (needs the site up; prefer A/B):
+
+```
+GET {baseUrl}/umbraco/management/api/v1/server/information
+```
+
+Call the result **SITE_MAJOR**. If A/B/C all return nothing, there is no Umbraco site in
+the workspace yet — say so and continue (nothing to guard). If multiple different majors
+are found (a mixed solution), surface all of them and ask which project is the target.
+
+## Step 3 — Compare and act
+
+- **`SITE_MAJOR == TARGET_MAJOR`** → ✅ Silent pass. Say one line confirming the match
+  (e.g. "Site is Umbraco {SITE_MAJOR}.x — matches these skills.") and proceed.
+- **`SITE_MAJOR != TARGET_MAJOR`** → ⛔ STOP. Do not generate version-specific code. Warn
+  as below, then only continue if the user explicitly confirms.
+
+**Which skill line to recommend** follows the repo's branch convention — the *latest*
+major lives on `main`; every older major `N` lives on a `vN/main` branch:
+
+- **`SITE_MAJOR < TARGET_MAJOR`** (site is older than these skills) → point at the older
+  line for the site's major:
+  ```
+  /plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v{SITE_MAJOR}/main
+  ```
+- **`SITE_MAJOR > TARGET_MAJOR`** (these skills are older than the site) → the latest major
+  lives on the default `main`, so re-add and update the default marketplace:
+  ```
+  /plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills
+  ```
+  If no released line exists yet for `SITE_MAJOR`, say so — the skills may not have caught
+  up to that major.
+
+Substitute the actual numbers when you present this. Template for the message:
+
+> ⚠️ **Version mismatch.** This site is Umbraco **{SITE_MAJOR}**, but the loaded skills
+> target Umbraco **{TARGET_MAJOR}**. The backoffice API differs between majors, so this
+> skill set will produce incorrect code for your site. Install the matching line:
+> `<computed command above>`
+>
+> For the Vercel Skills CLI (Cursor/Copilot/Windsurf), point the repo URL at the matching
+> branch (`main` for the latest major, `v{N}/main` for an older one).
+
+## When to run this
+
+Run it **once at the start** of any Umbraco backoffice task, before writing code. The
+entry skills (`umbraco-quickstart`, `umbraco-backoffice`, `umbraco-extension-template`)
+reference this guard as their first step. Re-run only if the workspace changes.


### PR DESCRIPTION
Promote `dev` → `main` for the **18.0.2** release (v18 line).

Merge with a **merge commit** (not squash) so the exact released commit stays reachable on `main` for tagging.

### Included since v18.0.1
- #90 — feat: version-guard preflight to prevent v17/v18 skill confusion
- #92 — ci: GitHub Actions skill validation (fast PR gate + nightly/manual full E2E)
- #94 — chore(release): 18.0.2 version bump (umbraco-cms-backoffice-skills → 18.0.2; testing stays 18.0.1)

After merge: tag `v18.0.2` on `main` and cut the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)