### PR TITLE
chore(release): 17.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Umbraco backoffice customization skills for Claude Code",
-    "version": "17.5.0",
+    "version": "17.5.1",
     "homepage": "https://github.com/hifi-phil/UmbracoCMS_Skills"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "umbraco-cms-backoffice-skills",
       "source": "./plugins/umbraco-backoffice-skills",
       "description": "Umbraco backoffice skills covering Foundation, Extension Types, Property Editors, Rich Text, Backend, and Setup",
-      "version": "17.5.0",
+      "version": "17.5.1",
       "category": "development",
       "author": {
         "name": "Phil Whittaker",

--- a/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
+++ b/plugins/umbraco-backoffice-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "umbraco-cms-backoffice-skills",
-  "version": "17.5.0",
+  "version": "17.5.1",
   "description": "Complete skill set for Umbraco backoffice customization - 57 skills covering Foundation concepts, Extension Types, Property Editors, Rich Text, Backend integration, and Setup tools",
   "author": {
     "name": "Phil W",


### PR DESCRIPTION
Release **17.5.1** (v17 line).

Bumps **umbraco-cms-backoffice-skills** 17.5.0 → 17.5.1 (plugin.json + marketplace entry) and marketplace `metadata.version` → 17.5.1. **umbraco-cms-backoffice-testing-skills** is unchanged since v17.5.0 and stays at 17.5.0.

### Changed since v17.5.0 (under `plugins/umbraco-backoffice-skills/`)
- #93 — ci: GitHub Actions skill validation (v17 line); example `.csproj` `SkipClientBuild` opt-in.

After merge: promote `v17/dev` → `v17/main` (merge commit), tag `v17.5.1`, and cut the GitHub release (not marked latest — v18 is the highest active major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)