### PR TITLE
feat: port version-guard + chrome-navigation skills to v17

### DIFF
--- a/plugins/umbraco-backoffice-skills/skills/umbraco-chrome-navigation/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-chrome-navigation/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: umbraco-chrome-navigation
+description: Drive and inspect the Umbraco backoffice reliably with Claude-in-Chrome browser automation. Use this WHENEVER you are about to use the mcp__claude-in-chrome tools against a running Umbraco backoffice — navigating sections, clicking tree items, filling forms, opening/closing modals, or visually verifying a backoffice extension (property editor, dashboard, workspace, tree, section, menu). The backoffice is Lit/web-components with open shadow DOM and modals that render off-screen, so the built-in find/read_page tools see nothing and screenshots lag behind the live DOM. This skill provides a shadow-DOM-piercing JS helper toolkit plus a navigation playbook so you read state from the DOM instead of guessing from pixels. Trigger even when the user only says "open the backoffice", "test the extension in Umbraco", "click through the backoffice", "log in and check it works", or "take a screenshot of the editor in Umbraco".
+version: 1.0.0
+location: managed
+---
+
+# Umbraco Backoffice Navigation (Claude-in-Chrome)
+
+## Why this skill exists
+
+The Umbraco backoffice is built from Lit web-components. That creates three problems for
+browser automation that will waste many tool calls if you fight them blind:
+
+1. **Everything is in (open) shadow DOM.** The built-in `find` and `read_page` tools do
+   not pierce shadow roots, so they return almost nothing on backoffice pages.
+2. **Modals portal into their own stacking context** and frequently render off the
+   ~1536px captured viewport, or stack so the newest one is off-screen.
+3. **Screenshots lag** behind the live DOM during modal transitions — you can screenshot
+   a frame that no longer reflects the current state and misread it completely.
+
+The fix is to stop navigating by pixels. Inject a small shadow-DOM-piercing helper and
+read state from the DOM (which never lags), acting by *label/text* instead of coordinates.
+Take a screenshot only when a picture is the actual deliverable (verifying how something
+*looks*, or evidence for the user) — not as your primary way to figure out what's on screen.
+
+## Setup (once per browser session)
+
+The toolkit lives at `scripts/umbraco-chrome-helpers.js` in this skill. Read that file and
+paste its entire contents into `mcp__claude-in-chrome__javascript_tool` (on the backoffice
+tab). It defines `window.__umb` and stashes its own source in `localStorage.__umbSrc`.
+
+A page load (navigate/reload/login redirect) wipes `window.__umb` but not localStorage, so
+**re-inject after every navigation with the one-liner:**
+
+```js
+eval(localStorage.__umbSrc)
+```
+
+Start a browser session the usual way first: `tabs_context_mcp` → `tabs_create_mcp` (or
+reuse the backoffice tab), then `navigate` to the backoffice at `<your-host>/umbraco`
+(this repo's host is `localhost:44325`).
+
+## The API
+
+All finders return the element's center `{x, y}` so you can fall back to the computer tool.
+
+| Call | Use it to |
+|------|-----------|
+| `__umb.snapshot()` | List visible actionable elements as `tag[role] "label" @x,y` — "what can I click" |
+| `__umb.find(text, {role, tag})` | Locate elements by label/text (string or RegExp) with coords |
+| `__umb.click(text, {role, tag, nth})` | Click most in-workspace / in-modal buttons and options |
+| `__umb.fill(labelSubstr, value)` | Set an `<uui-input>`/`<input>`/`<textarea>` (dispatches input+change) |
+| `__umb.modals()` | List open modals/sidebars/dialogs + their action buttons |
+| `__umb.waitFor(text, {role})` | Poll until an element appears (the section tree loads async) |
+| `__umb.waitGone(text)` | Poll until an element disappears (e.g. a modal closed) |
+| `__umb.section(name)` | Locate a section tab (Content/Settings/…) — returns coords to click with the computer tool |
+| `__umb.treeActions(itemName)` | Open a tree item's "View actions for 'X'" menu |
+
+## The one rule that saves you: synthetic vs. trusted clicks
+
+`__umb.click()` uses the element's real `.click()`. That works for **buttons and options
+inside a workspace or modal** (Save, Submit, Discard, result rows, create options, etc.).
+
+It does **NOT** work for two things, because they need a *trusted* user gesture:
+- **Section tabs** (Content, Settings…) — the SPA router ignores synthetic clicks.
+- **Sidebar tree GROUP headers** (the `h3` "Structure"/"Templating") that expand/collapse.
+
+For those, get coords from `__umb.find(...)` (or `__umb.section(...)`) and click them with
+`mcp__claude-in-chrome__computer` (`left_click` at `{x,y}`) — a real, trusted click.
+
+So the division of labor is: **DOM helpers to see state and do in-page actions; the
+computer tool (at helper-provided coords) for route navigation and tree-group toggles.**
+
+## Gotchas the helpers expose for you
+
+- **Hidden "discard changes" modal.** Leaving a workspace with unsaved state pops
+  `umb-discard-changes-modal`, which silently blocks navigation. If a nav seems to do
+  nothing, run `__umb.modals()` — you'll see it — then `__umb.click('Discard changes')`
+  (or `'Save'`) to proceed.
+- **Blank create workspaces.** Deep-linking to a `…/create/…` workspace URL frequently
+  renders blank. Enter create via the tree/collection **"Create"** action instead.
+- **Async tree load.** After navigating to a section, the sidebar tree loads a moment
+  later. `__umb.waitFor('<a known item>')` before acting.
+- **Session invalidation.** Recreating the DB (fresh unattended install) invalidates the
+  old token; the tab bounces to `/umbraco/login`. Re-inject helpers, then log in by
+  setting the username/password inputs and clicking the submit button.
+- **Privacy guard.** Do not return hrefs/URLs/base64 in bulk from `javascript_tool` — the
+  guard blocks the whole result. Return labels + coords only (the helpers already do this).
+
+## Reliability boundary — prefer the API for setup
+
+Driving the *UI* through multi-step **setup** (create data type → document type → content)
+is inherently fragile: async trees, blank create workspaces, discard guards. When you only
+need the entities to *exist*, the **Management API is the right surface**, via the Umbraco
+e2e/Playwright testhelpers (`@umbraco-cms/acceptance-test-helpers`), which authenticate
+properly and seed with a few `umbracoApi.*` calls. Use this skill for the parts that must
+happen in the live backoffice UI (verifying a custom editor renders and behaves, clicking
+through a flow, capturing a screenshot). Note: the backoffice OAuth token is held in memory,
+not in localStorage/sessionStorage, so it can't be borrowed from the page for direct API
+calls from Claude-in-Chrome.
+
+## Typical loop
+
+1. `navigate` to the backoffice tab, inject the toolkit (or `eval(localStorage.__umbSrc)`).
+2. `__umb.snapshot()` / `__umb.find(...)` to see what's there — not a screenshot.
+3. Navigate sections/expand tree groups with the computer tool at helper coords; do
+   in-page actions with `__umb.click` / `__umb.fill`.
+4. After each step, verify with `__umb.find` / `__umb.modals` / `location.pathname`.
+5. Take **one** screenshot at the end if the deliverable is visual (how it looks) or is
+   evidence for the user.

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-chrome-navigation/scripts/umbraco-chrome-helpers.js
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-chrome-navigation/scripts/umbraco-chrome-helpers.js
@@ -1,0 +1,253 @@
+/**
+ * Umbraco backoffice helpers for Claude-in-Chrome (mcp__claude-in-chrome__javascript_tool).
+ * ===========================================================================================
+ *
+ * WHY THIS EXISTS
+ *   The backoffice is Lit/web-components: everything lives in (open) shadow DOM, modals
+ *   portal into their own stacking context and often render off the ~1536px captured
+ *   viewport, and screenshots LAG behind the live DOM during modal transitions. The
+ *   built-in `find`/`read_page` tools can't see into shadow DOM. These helpers pierce
+ *   shadow DOM so you inspect state and act by *label/text* instead of pixels.
+ *
+ * INSTALL (once per browser session):
+ *   Paste this whole file into javascript_tool. It defines `window.__umb` AND stashes its
+ *   own source in localStorage.__umbSrc.
+ *
+ * RE-INJECT after any navigate/reload (a page load wipes window.__umb, but localStorage
+ * survives), one-liner:
+ *   eval(localStorage.__umbSrc)
+ *
+ * ─────────────────────────────────────────────────────────────────────────────────────────
+ * NAVIGATION CHEATSHEET (learned the hard way)
+ *
+ *   SEE state, never trust a lone screenshot mid-transition:
+ *     __umb.snapshot()  → visible actionable elements as `tag[role] "label" @x,y`
+ *     __umb.find(text)  → matches with center {x,y} coords (regex or substring)
+ *     __umb.modals()    → open modals/sidebars/dialogs + their action buttons
+ *                          (this is how you catch a HIDDEN "discard changes" modal that
+ *                           is silently blocking navigation)
+ *
+ *   DO things:
+ *     __umb.fill(labelSubstr, value)   → set an input (dispatches input+change)
+ *     __umb.click(text, {role,tag,nth})→ click most in-workspace buttons/options
+ *
+ *   USE THE COMPUTER TOOL (real, trusted click) for, using coords from __umb.find:
+ *     - Section tabs (Content/Settings/…)   ← the SPA router ignores synthetic clicks
+ *     - Sidebar tree GROUP headers (h3 "Structure") to expand/collapse
+ *     Synthetic .click() works for buttons INSIDE a workspace/modal; it does NOT drive
+ *     the router or those toggles.
+ *
+ *   GOTCHAS this surfaces for you:
+ *     - Deep-linking to a *create* workspace (…/document-type/create/…) frequently renders
+ *       BLANK. Enter create via the tree/collection "Create" action instead.
+ *     - Leaving a workspace with unsaved state pops `umb-discard-changes-modal`; it blocks
+ *       navigation. Click "Discard changes" (or "Save") to proceed.
+ *     - The section tree loads ASYNC after navigation — waitFor() a known item first.
+ *
+ *   RELIABILITY NOTE: driving the UI for multi-step *setup* (create data type → doc type →
+ *   content) is inherently fragile. When you just need the entities to exist, prefer the
+ *   Management API via the e2e/Playwright testhelpers (they authenticate properly). The
+ *   token is in-memory in the backoffice and cannot be borrowed from the page.
+ *
+ *   Don't return hrefs/URLs/base64 in bulk from javascript_tool — the privacy guard blocks
+ *   the whole result. Return labels + coords only.
+ * ─────────────────────────────────────────────────────────────────────────────────────────
+ */
+function __umbInstall() {
+  const U = {};
+
+  // Depth-first walk of the whole DOM, descending into every open shadow root.
+  U._walk = function* (root) {
+    root = root || document;
+    for (const el of root.querySelectorAll("*")) {
+      yield el;
+      if (el.shadowRoot) yield* U._walk(el.shadowRoot);
+    }
+  };
+
+  U._vis = (el) => {
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  };
+
+  U._label = (el) =>
+    (
+      (el.getAttribute &&
+        (el.getAttribute("label") ||
+          el.getAttribute("aria-label") ||
+          el.getAttribute("name") ||
+          el.getAttribute("placeholder"))) ||
+      el.textContent ||
+      ""
+    )
+      .replace(/\s+/g, " ")
+      .trim();
+
+  U._center = (el) => {
+    const r = el.getBoundingClientRect();
+    return { x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) };
+  };
+  U._rect = (el) => {
+    const r = el.getBoundingClientRect();
+    return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
+  };
+  U._match = (label, text, exact) =>
+    text instanceof RegExp ? text.test(label) : exact ? label === text : label.toLowerCase().includes(String(text).toLowerCase());
+
+  const CLICKABLE = [
+    "uui-button", "button", "a", "uui-menu-item", "uui-ref-item", "uui-ref-node",
+    "uui-card", "uui-tab", "li", "uui-symbol-expand", "uui-toggle", "uui-checkbox",
+  ];
+  const INTERACTIVE = CLICKABLE.concat([
+    "uui-input", "input", "uui-textarea", "textarea", "uui-select", "uui-combobox", "select",
+  ]);
+
+  /** Find matches by label/text. opts: {role, tag, exact, visibleOnly=true, limit=15}. */
+  U.find = (text, opts) => {
+    opts = opts || {};
+    const { role, tag, exact = false, visibleOnly = true, limit = 15 } = opts;
+    const out = [];
+    for (const el of U._walk()) {
+      if (visibleOnly && !U._vis(el)) continue;
+      const t = el.tagName.toLowerCase();
+      if (tag && t !== tag) continue;
+      if (role && (el.getAttribute("role") || "") !== role) continue;
+      const label = U._label(el);
+      if (!label) continue;
+      if (U._match(label, text, exact)) {
+        out.push({ tag: t, role: el.getAttribute("role") || null, label: label.slice(0, 60), ...U._center(el) });
+        if (out.length >= limit) break;
+      }
+    }
+    return out;
+  };
+
+  /**
+   * Click the first element whose label/text matches. Restricted to clickable tags
+   * unless {tag} or {any:true} given. Works for in-workspace/in-modal buttons; NOT for
+   * section tabs or tree group toggles (use the computer tool at the returned coords).
+   * opts: {role, tag, exact, nth=0, any=false}. Returns {clicked,tag,x,y} or null.
+   */
+  U.click = (text, opts) => {
+    opts = opts || {};
+    const { role, tag, exact = false, nth = 0, any = false } = opts;
+    let seen = 0;
+    for (const el of U._walk()) {
+      if (!U._vis(el)) continue;
+      const t = el.tagName.toLowerCase();
+      if (tag ? t !== tag : !any && !CLICKABLE.includes(t)) continue;
+      if (role && (el.getAttribute("role") || "") !== role) continue;
+      const label = U._label(el);
+      if (!label || !U._match(label, text, exact)) continue;
+      if (seen++ < nth) continue;
+      el.scrollIntoView({ block: "center", inline: "center" });
+      el.click();
+      return { clicked: label.slice(0, 60), tag: t, ...U._center(el) };
+    }
+    return null;
+  };
+
+  /**
+   * Fill an <uui-input>/<input>/<textarea> located by its label/aria-label/placeholder
+   * substring. Dispatches input & change (composed) so Lit handlers fire. opts: {nth=0}.
+   */
+  U.fill = (labelSubstr, value, opts) => {
+    opts = opts || {};
+    const { nth = 0 } = opts;
+    let seen = 0;
+    for (const el of U._walk()) {
+      const t = el.tagName.toLowerCase();
+      if (!["uui-input", "input", "uui-textarea", "textarea"].includes(t)) continue;
+      if (!U._vis(el)) continue;
+      const lab = (el.getAttribute("label") || el.getAttribute("aria-label") || el.getAttribute("placeholder") || "").toLowerCase();
+      if (!lab.includes(labelSubstr.toLowerCase())) continue;
+      if (seen++ < nth) continue;
+      el.scrollIntoView({ block: "center" });
+      el.value = value;
+      el.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+      el.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      return { filled: labelSubstr, value, tag: t };
+    }
+    return null;
+  };
+
+  /** List open modals/sidebars/dialogs with their action buttons (incl. discard/keep). */
+  U.modals = () => {
+    const out = [];
+    for (const el of U._walk()) {
+      const t = el.tagName.toLowerCase();
+      if (!/(modal|dialog|sidebar)/.test(t) || !U._vis(el)) continue;
+      const acts = new Set();
+      for (const b of U._walk(el.shadowRoot || el)) {
+        if (b.tagName.toLowerCase() !== "uui-button" || !U._vis(b)) continue;
+        const l = U._label(b);
+        if (l && /submit|save|cancel|choose|create|close|confirm|delete|remove|select|done|back|next|discard|keep|apply/i.test(l)) {
+          acts.add(l.slice(0, 30));
+        }
+      }
+      out.push({ tag: t, ...U._rect(el), actions: [...acts] });
+    }
+    return out;
+  };
+
+  /** Compact list of visible, actionable elements: `tag[role] "label" @x,y`. opts:{limit=70}. */
+  U.snapshot = (opts) => {
+    opts = opts || {};
+    const { limit = 70 } = opts;
+    const out = [];
+    for (const el of U._walk()) {
+      if (!U._vis(el)) continue;
+      const t = el.tagName.toLowerCase();
+      const role = el.getAttribute("role");
+      if (!INTERACTIVE.includes(t) && !role) continue;
+      const label = U._label(el);
+      if (!label) continue;
+      const c = U._center(el);
+      out.push(`${t}${role ? `[${role}]` : ""} "${label.slice(0, 50)}" @${c.x},${c.y}`);
+      if (out.length >= limit) break;
+    }
+    return out;
+  };
+
+  /** Poll until an element matching text appears. opts:{role,timeout=8000,interval=250}. */
+  U.waitFor = async (text, opts) => {
+    opts = opts || {};
+    const { role, timeout = 8000, interval = 250 } = opts;
+    const end = Date.now() + timeout;
+    while (Date.now() < end) {
+      const hits = U.find(text, { role, limit: 1 });
+      if (hits.length) return hits[0];
+      await new Promise((r) => setTimeout(r, interval));
+    }
+    return null;
+  };
+
+  /** Poll until an element matching text is GONE (e.g. a modal closed). */
+  U.waitGone = async (text, opts) => {
+    opts = opts || {};
+    const { timeout = 8000, interval = 250 } = opts;
+    const end = Date.now() + timeout;
+    while (Date.now() < end) {
+      if (!U.find(text, { limit: 1 }).length) return true;
+      await new Promise((r) => setTimeout(r, interval));
+    }
+    return false;
+  };
+
+  /**
+   * Locate a top-level section tab (Content/Settings/…). Returns {x,y,...} — then click
+   * those coords with the COMPUTER TOOL (the router ignores synthetic clicks).
+   */
+  U.section = (name) => U.find(name, { role: "tab", limit: 1 })[0] || null;
+
+  /** Open a tree item's actions menu (the hover-only "View actions for 'X'" button). */
+  U.treeActions = (itemName) =>
+    U.click(`View actions for '${itemName}'`, { tag: "button" }) || U.click(`actions for '${itemName}'`);
+
+  window.__umb = U;
+  return "umb helpers ready -> " + Object.keys(U).filter((k) => !k.startsWith("_")).join(", ");
+}
+
+// Stash source for one-liner re-injection after reloads, then install now.
+try { localStorage.setItem("__umbSrc", "(" + __umbInstall.toString() + ")()"); } catch (e) {}
+__umbInstall();

--- a/plugins/umbraco-backoffice-skills/skills/umbraco-version-guard/SKILL.md
+++ b/plugins/umbraco-backoffice-skills/skills/umbraco-version-guard/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: umbraco-version-guard
+description: Deterministically verify that the Umbraco major of the site you are working on matches the major these skills target. Run this FIRST, before any Umbraco backoffice work, to avoid mixing guidance across Umbraco majors (e.g. 17 vs 18 vs 19). Trigger on the first Umbraco task in a session, or whenever the site's version is uncertain.
+version: 1.0.0
+location: managed
+allowed-tools: Bash, Read, Grep, Glob, WebFetch
+user_invocable: true
+---
+
+# Umbraco Version Guard
+
+## What this skill does
+
+The Umbraco backoffice API changes between majors (tree data sources, auth, OpenAPI
+registration, and more). **These skills target one specific major.** Applying them to a
+site on a different major produces confidently-wrong code.
+
+This skill is a **preflight check**: it derives the target major from the plugin itself
+(so it never goes stale as new majors ship), detects the target site's major
+deterministically, compares them, and STOPS with the correct install command on a
+mismatch. Nothing here hardcodes a specific major number — both sides are computed.
+
+## Step 1 — Determine the major these skills target
+
+The plugin's own version is the source of truth, and it bumps every major at release. Read
+it and take the leading number:
+
+```bash
+# Primary: the installed plugin's version. First path is the Claude Code plugin layout;
+# the greps are fallbacks for when the skill was copied flat into an editor's skills dir.
+cat "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null \
+  || cat ../../.claude-plugin/plugin.json 2>/dev/null \
+  | grep -m1 '"version"' | grep -oE '[0-9]+' | head -1
+```
+
+Call this **TARGET_MAJOR**. If none of the paths resolve (a flat copy with no
+`plugin.json` alongside), fall back to the marketplace version, and only then to reading
+the value a sibling skill states — never invent a number. If you genuinely cannot
+determine it, say so and skip the guard rather than guessing.
+
+## Step 2 — Detect the site's Umbraco major (deterministic, no running instance needed)
+
+Try these signals in order and stop at the first that yields a number. Each extracts just
+the **major**, so it works with `17.0.0`, `17.*`, `[17.0.0,)`, or plain `17`.
+
+**A. `Umbraco.Cms` package reference (ground truth — what is actually installed).** Covers
+`*.csproj` PackageReference and central-package-management `*.props` (PackageVersion); the
+trailing `"` after `Cms` excludes `Umbraco.Cms.DevelopmentMode` etc.
+
+```bash
+grep -rhoE 'Umbraco\.Cms"[^0-9]*[0-9]+' --include='*.csproj' --include='*.props' . 2>/dev/null \
+  | grep -oE '[0-9]+$' | sort -u
+```
+
+**B. Fallback — the backoffice client dependency major** (handles `^17.0.0`, `~17.0.0`, `17.0.0`):
+
+```bash
+grep -rhoE '"@umbraco-cms/backoffice":[^0-9]*[0-9]+' --include='package.json' . 2>/dev/null \
+  | grep -oE '[0-9]+$' | sort -u
+```
+
+**C. Last resort — a running instance's Server Information API** (needs the site up; prefer A/B):
+
+```
+GET {baseUrl}/umbraco/management/api/v1/server/information
+```
+
+Call the result **SITE_MAJOR**. If A/B/C all return nothing, there is no Umbraco site in
+the workspace yet — say so and continue (nothing to guard). If multiple different majors
+are found (a mixed solution), surface all of them and ask which project is the target.
+
+## Step 3 — Compare and act
+
+- **`SITE_MAJOR == TARGET_MAJOR`** → ✅ Silent pass. Say one line confirming the match
+  (e.g. "Site is Umbraco {SITE_MAJOR}.x — matches these skills.") and proceed.
+- **`SITE_MAJOR != TARGET_MAJOR`** → ⛔ STOP. Do not generate version-specific code. Warn
+  as below, then only continue if the user explicitly confirms.
+
+**Which skill line to recommend** follows the repo's branch convention — the *latest*
+major lives on `main`; every older major `N` lives on a `vN/main` branch:
+
+- **`SITE_MAJOR < TARGET_MAJOR`** (site is older than these skills) → point at the older
+  line for the site's major:
+  ```
+  /plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v{SITE_MAJOR}/main
+  ```
+- **`SITE_MAJOR > TARGET_MAJOR`** (these skills are older than the site) → the latest major
+  lives on the default `main`, so re-add and update the default marketplace:
+  ```
+  /plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills
+  ```
+  If no released line exists yet for `SITE_MAJOR`, say so — the skills may not have caught
+  up to that major.
+
+Substitute the actual numbers when you present this. Template for the message:
+
+> ⚠️ **Version mismatch.** This site is Umbraco **{SITE_MAJOR}**, but the loaded skills
+> target Umbraco **{TARGET_MAJOR}**. The backoffice API differs between majors, so this
+> skill set will produce incorrect code for your site. Install the matching line:
+> `<computed command above>`
+>
+> For the Vercel Skills CLI (Cursor/Copilot/Windsurf), point the repo URL at the matching
+> branch (`main` for the latest major, `v{N}/main` for an older one).
+
+## When to run this
+
+Run it **once at the start** of any Umbraco backoffice task, before writing code. The
+entry skills (`umbraco-quickstart`, `umbraco-backoffice`, `umbraco-extension-template`)
+reference this guard as their first step. Re-run only if the workspace changes.


### PR DESCRIPTION
Brings the v17 line to content parity with v18 by porting two skills that only existed on the v18 line.

## Skills added
- **umbraco-version-guard** (from #90) — a major-agnostic preflight that derives the target major from the plugin's own version, so it runs correctly on v17 (target major 17) with no logic changes. Only the illustrative version-format examples were localized `18` → `17`; the detection and branch-recommendation logic (including `{SITE_MAJOR}` templating) is verbatim. Especially useful on v17 to stop v17 skills being applied to a v18 site.
- **umbraco-chrome-navigation** (from #85) — Claude-in-Chrome validation helper. Copied verbatim; no v18-specific content (its `@umbraco-cms/acceptance-test-helpers` reference is correct for v17 too).

## Validation
- Local link validation: 75 skills, 0 issues.
- Local code analysis: 75 skills, 509 code blocks, 0 issues.
- No new examples/tests, so the mocked/E2E suites are unaffected.

v17 now has 75 skills, matching v18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)